### PR TITLE
docs: add @mcp-framework/docs package documentation

### DIFF
--- a/docs/DocsPackage/_category_.json
+++ b/docs/DocsPackage/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Docs Package",
+  "position": 7,
+  "collapsed": false,
+  "link": {
+    "type": "generated-index",
+    "description": "Build MCP documentation servers with @mcp-framework/docs"
+  }
+}

--- a/docs/DocsPackage/caching.md
+++ b/docs/DocsPackage/caching.md
@@ -1,0 +1,119 @@
+---
+id: docs-package-caching
+title: Caching
+sidebar_position: 5
+---
+
+# Caching
+
+`@mcp-framework/docs` includes a built-in caching layer that reduces HTTP requests to your documentation site.
+
+## Default MemoryCache
+
+The default cache is an in-memory LRU (Least Recently Used) cache with TTL (Time-To-Live) expiry.
+
+### What Gets Cached
+
+| Content | Cache Key Pattern |
+|---------|-------------------|
+| `llms.txt` content | `index:{baseUrl}` |
+| `llms-full.txt` content | `full:{baseUrl}` |
+| Individual pages | `page:{slug}` |
+| Search results | `search:{query}:{section}:{limit}` |
+| Parsed section tree | `sections:{baseUrl}` |
+
+### Configuration
+
+```typescript
+import { MemoryCache, LlmsTxtSource } from "@mcp-framework/docs";
+
+const cache = new MemoryCache({
+  maxEntries: 200,       // Default: 100
+  ttlMs: 600_000,        // Default: 300_000 (5 minutes)
+});
+
+const source = new LlmsTxtSource({
+  baseUrl: "https://docs.example.com",
+  cache,
+});
+```
+
+## Cache Behavior
+
+- **Lazy expiry** — Expired entries are cleaned on access, not via background timers
+- **LRU eviction** — Oldest entry evicted when `maxEntries` is reached
+- **Per-entry TTL** — Each `set()` call can override the default TTL
+- **Overwrite resets TTL** — Re-storing a key resets the expiry timer
+
+## Custom Cache Implementation
+
+Implement the `Cache` interface for Redis, SQLite, etc.:
+
+```typescript
+import { Cache, CacheStats } from "@mcp-framework/docs";
+
+interface Cache {
+  get<T>(key: string): Promise<T | null>;
+  set<T>(key: string, value: T, ttlMs?: number): Promise<void>;
+  delete(key: string): Promise<void>;
+  clear(): Promise<void>;
+  stats(): CacheStats;
+}
+```
+
+### Example: Redis Cache
+
+```typescript
+import { Cache, CacheStats } from "@mcp-framework/docs";
+import { createClient } from "redis";
+
+class RedisCache implements Cache {
+  private client;
+  private defaultTtl: number;
+  private _hits = 0;
+  private _misses = 0;
+
+  constructor(redisUrl: string, ttlMs = 300_000) {
+    this.client = createClient({ url: redisUrl });
+    this.defaultTtl = ttlMs;
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    const value = await this.client.get(`docs:${key}`);
+    if (!value) { this._misses++; return null; }
+    this._hits++;
+    return JSON.parse(value);
+  }
+
+  async set<T>(key: string, value: T, ttlMs?: number): Promise<void> {
+    const ttl = Math.ceil((ttlMs ?? this.defaultTtl) / 1000);
+    await this.client.set(`docs:${key}`, JSON.stringify(value), { EX: ttl });
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.del(`docs:${key}`);
+  }
+
+  async clear(): Promise<void> {
+    const keys = await this.client.keys("docs:*");
+    if (keys.length > 0) await this.client.del(keys);
+    this._hits = 0; this._misses = 0;
+  }
+
+  stats(): CacheStats {
+    return { hits: this._hits, misses: this._misses, size: -1 };
+  }
+}
+```
+
+## Tuning Refresh Interval
+
+| Use Case | `refreshInterval` |
+|----------|-------------------|
+| Development | `60_000` (1 min) |
+| Production (default) | `300_000` (5 min) |
+| Stable docs | `3_600_000` (1 hour) |
+
+:::info
+Cache invalidation is TTL-based only in v1. There is no webhook-based or push-based invalidation.
+:::

--- a/docs/DocsPackage/cli.md
+++ b/docs/DocsPackage/cli.md
@@ -1,0 +1,95 @@
+---
+id: docs-package-cli
+title: CLI & Scaffolding
+sidebar_position: 6
+---
+
+# CLI & Project Scaffolding
+
+`@mcp-framework/docs` includes a CLI that scaffolds a ready-to-run documentation MCP server.
+
+## Creating a Project
+
+```bash
+npx create-docs-server my-api-docs
+```
+
+This creates:
+
+```
+my-api-docs/
+├── src/
+│   └── index.ts          # Pre-configured DocsServer
+├── package.json          # All dependencies included
+├── tsconfig.json
+├── .env.example          # Configuration template
+├── .gitignore
+└── README.md             # Setup + MCP client config instructions
+```
+
+## Setup After Scaffolding
+
+```bash
+cd my-api-docs
+cp .env.example .env
+# Edit .env with your documentation site URL
+npm run build
+npm start
+```
+
+## Connecting to MCP Clients
+
+### Claude Code
+
+```bash
+claude mcp add my-api-docs -- node /path/to/my-api-docs/dist/index.js
+```
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "my-api-docs": {
+      "command": "node",
+      "args": ["/path/to/my-api-docs/dist/index.js"],
+      "env": {
+        "DOCS_BASE_URL": "https://docs.myapi.com"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to MCP settings:
+
+```json
+{
+  "my-api-docs": {
+    "command": "node",
+    "args": ["/path/to/my-api-docs/dist/index.js"],
+    "env": {
+      "DOCS_BASE_URL": "https://docs.myapi.com"
+    }
+  }
+}
+```
+
+## SKILL.md Template
+
+The package includes a `SKILL.md.template` that teaches Claude Code how to approach integrations against your API:
+
+```bash
+cp node_modules/@mcp-framework/docs/SKILL.md.template SKILL.md
+```
+
+Edit the `<!-- CUSTOMIZE -->` sections with your API-specific patterns:
+- Authentication setup
+- SDK initialization
+- Common API call patterns
+- Error handling
+- Common pitfalls

--- a/docs/DocsPackage/custom-adapters.md
+++ b/docs/DocsPackage/custom-adapters.md
@@ -1,0 +1,140 @@
+---
+id: docs-package-custom-adapters
+title: Custom Source Adapters
+sidebar_position: 7
+---
+
+# Custom Source Adapters
+
+Build your own source adapter by implementing the `DocSource` interface.
+
+## Full Implementation
+
+```typescript
+import {
+  DocSource, DocPage, DocSearchResult,
+  DocSection, DocSearchOptions,
+} from "@mcp-framework/docs";
+
+class MyCustomSource implements DocSource {
+  name = "my-custom-docs";
+
+  async search(query: string, options?: DocSearchOptions): Promise<DocSearchResult[]> {
+    const limit = options?.limit ?? 10;
+    const response = await fetch(`https://api.example.com/search?q=${query}`);
+    const data = await response.json();
+
+    return data.results.slice(0, limit).map((item: any) => ({
+      slug: item.path,
+      url: `https://docs.example.com/${item.path}`,
+      title: item.title,
+      snippet: item.excerpt,
+      section: item.category,
+      score: item.relevance,
+    }));
+  }
+
+  async getPage(slug: string): Promise<DocPage | null> {
+    const response = await fetch(`https://api.example.com/pages/${slug}`);
+    if (!response.ok) return null;
+
+    const data = await response.json();
+    return {
+      slug,
+      url: `https://docs.example.com/${slug}`,
+      title: data.title,
+      content: data.markdown,
+      section: data.category,
+    };
+  }
+
+  async listSections(): Promise<DocSection[]> {
+    const response = await fetch("https://api.example.com/sections");
+    const data = await response.json();
+
+    return data.map((s: any) => ({
+      name: s.title,
+      slug: s.id,
+      url: `https://docs.example.com/${s.id}`,
+      children: [],
+      pageCount: s.page_count,
+    }));
+  }
+
+  async getIndex(): Promise<string> { return ""; }
+  async getFullContent(): Promise<string> { return ""; }
+
+  async healthCheck(): Promise<{ ok: boolean; message?: string }> {
+    try {
+      const response = await fetch("https://api.example.com/health");
+      return { ok: response.ok };
+    } catch (error) {
+      return { ok: false, message: (error as Error).message };
+    }
+  }
+}
+```
+
+## Using Your Custom Source
+
+```typescript
+import { DocsServer } from "@mcp-framework/docs";
+
+const server = new DocsServer({
+  source: new MyCustomSource(),
+  name: "my-custom-docs",
+  version: "1.0.0",
+});
+
+server.start();
+```
+
+## Extending LlmsTxtSource
+
+If your site publishes `llms.txt` but has a custom search API, extend `LlmsTxtSource`:
+
+```typescript
+import { LlmsTxtSource, DocSearchResult, DocSearchOptions } from "@mcp-framework/docs";
+
+class MyEnhancedSource extends LlmsTxtSource {
+  override get name(): string {
+    return `enhanced:${this.baseUrl}`;
+  }
+
+  override async search(query: string, options?: DocSearchOptions): Promise<DocSearchResult[]> {
+    try {
+      // Try custom search API
+      const response = await fetch(`${this.baseUrl}/api/my-search?q=${query}`);
+      if (response.ok) return this.mapResults(await response.json());
+    } catch {
+      // Fall back to local text search
+    }
+    return super.search(query, options);
+  }
+
+  private mapResults(data: any[]): DocSearchResult[] {
+    return data.map((item, i) => ({
+      slug: item.slug, url: item.url, title: item.title,
+      snippet: item.excerpt || "", score: 1 - i / data.length,
+    }));
+  }
+}
+```
+
+## Error Handling
+
+Use the built-in error classes for consistent behavior:
+
+```typescript
+import { DocFetchError, DocParseError } from "@mcp-framework/docs";
+
+// HTTP failures
+throw new DocFetchError(url, response.status, response.statusText);
+
+// Parse failures
+throw new DocParseError(`Page ${slug} has no markdown content`);
+```
+
+:::tip
+The tools catch `DocSourceError` subclasses and return user-friendly messages. Never expose stack traces to the MCP client.
+:::

--- a/docs/DocsPackage/fumadocs-setup.md
+++ b/docs/DocsPackage/fumadocs-setup.md
@@ -1,0 +1,125 @@
+---
+id: docs-package-fumadocs-setup
+title: Fumadocs Setup
+sidebar_position: 8
+---
+
+# Fumadocs Setup Guide
+
+Configure your [Fumadocs](https://fumadocs.vercel.app/) site to work with `@mcp-framework/docs`.
+
+## Step 1: Enable llms.txt
+
+### `app/llms.txt/route.ts`
+
+```typescript
+import { source } from "@/lib/source";
+
+export function GET() {
+  const content = source.llms().index();
+  return new Response(content, {
+    headers: { "Content-Type": "text/plain" },
+  });
+}
+```
+
+### `app/llms-full.txt/route.ts`
+
+```typescript
+import { source } from "@/lib/source";
+
+export async function GET() {
+  const content = await source.llms().full();
+  return new Response(content, {
+    headers: { "Content-Type": "text/plain" },
+  });
+}
+```
+
+## Step 2: Enable Search API (Recommended)
+
+### `app/api/search/route.ts`
+
+```typescript
+import { source } from "@/lib/source";
+import { createFromSource } from "fumadocs-core/search/server";
+
+export const { GET } = createFromSource(source);
+```
+
+This creates `GET /api/search?query=...` returning Orama search results.
+
+## Step 3: Verify Endpoints
+
+```bash
+curl https://docs.yoursite.com/llms.txt
+curl https://docs.yoursite.com/llms-full.txt
+curl "https://docs.yoursite.com/api/search?query=getting+started"
+```
+
+## Step 4: Create Your MCP Server
+
+```bash
+npx create-docs-server my-api-docs
+cd my-api-docs
+```
+
+Edit `.env`:
+
+```bash
+DOCS_BASE_URL=https://docs.yoursite.com
+DOCS_SERVER_NAME=my-api-docs
+```
+
+```bash
+npm run build && npm start
+```
+
+## Expected llms.txt Format
+
+```markdown
+# Project Name
+
+> Project description
+
+## Section Name
+
+- [Page Title](https://docs.example.com/docs/page-slug): Page description
+
+## Another Section
+
+- [Another Page](https://docs.example.com/docs/another): Description
+```
+
+## Expected Search API Response
+
+```json
+[
+  {
+    "id": "/docs/page-slug",
+    "url": "/docs/page-slug",
+    "type": "page",
+    "content": "matched text...",
+    "structured": { "heading": "Section Heading" }
+  }
+]
+```
+
+## Troubleshooting
+
+### "No results found" for all searches
+
+- Verify `llms-full.txt` is accessible and contains content
+- Check `/api/search` returns valid JSON
+- Check `refreshInterval` — cached empty results persist until TTL expires
+
+### "Page not found" for valid pages
+
+- Check slug matches `llms.txt` URL paths
+- Verify `.mdx` endpoint: `curl https://docs.yoursite.com/docs/your-page.mdx`
+- Try the full slug path (e.g., `docs/auth/api-keys` not just `api-keys`)
+
+### Stale content
+
+- Reduce `refreshInterval` for faster invalidation (default: 5 min)
+- Set to `60_000` (1 min) during development

--- a/docs/DocsPackage/overview.md
+++ b/docs/DocsPackage/overview.md
@@ -1,0 +1,93 @@
+---
+id: docs-package-overview
+title: Docs Package Overview
+sidebar_position: 1
+---
+
+# @mcp-framework/docs
+
+:::tip Turn Your Docs into an AI Superpower
+`@mcp-framework/docs` lets API providers spin up an MCP documentation server in minutes. AI agents in Claude Code, Cursor, or any MCP client get tools to search, browse, and retrieve your documentation — enabling them to write correct integration code on the first try!
+:::
+
+## What is @mcp-framework/docs?
+
+A companion package built on top of mcp-framework that provides:
+
+1. **Source Adapters** — connect to your documentation backend (Fumadocs, any site with `llms.txt`)
+2. **MCP Tools** — `search_docs`, `get_page`, `list_sections` that AI agents can call
+3. **DocsServer** — a convenience wrapper that wires everything together
+4. **CLI Scaffolder** — `npx create-docs-server my-api-docs` to generate a project in seconds
+
+## Quick Start
+
+```typescript
+import { DocsServer, FumadocsRemoteSource } from "@mcp-framework/docs";
+
+const source = new FumadocsRemoteSource({
+  baseUrl: "https://docs.myapi.com",
+});
+
+const server = new DocsServer({
+  source,
+  name: "my-api-docs",
+  version: "1.0.0",
+});
+
+server.start();
+```
+
+Or scaffold a project instantly:
+
+```bash
+npx create-docs-server my-api-docs
+cd my-api-docs
+cp .env.example .env   # Set your docs URL
+npm run build && npm start
+```
+
+## How It Works
+
+```
+Your Docs Site                    MCP Client (Claude Code, Cursor, etc.)
+┌──────────────┐                  ┌──────────────────────────────┐
+│  llms.txt    │◄────fetch────────│                              │
+│  /api/search │                  │   search_docs("auth")        │
+│  pages.mdx   │    DocsServer    │   get_page("getting-started")│
+└──────────────┘   ┌──────────┐   │   list_sections()            │
+                   │ Source   │   │                              │
+                   │ Adapter  │◄──┤  AI Agent writes integration │
+                   │ + Cache  │   │  code using your docs        │
+                   └──────────┘   └──────────────────────────────┘
+```
+
+## Architecture
+
+`@mcp-framework/docs` is a **consumer** of mcp-framework, not a fork:
+
+```
+mcp-framework (peer dependency)
+    └── @mcp-framework/docs
+            ├── DocSource interface
+            ├── Pre-built tools (SearchDocs, GetPage, ListSections)
+            ├── DocsServer convenience class
+            └── CLI template
+```
+
+## Prerequisites
+
+Your documentation site must serve at least:
+
+- `/llms.txt` — a structured index of your documentation (required)
+- `/llms-full.txt` — full content of all documentation pages (required for search)
+- `/api/search` — Fumadocs Orama search endpoint (optional, for higher-quality search)
+
+## Next Steps
+
+- [Source Adapters](./sources) — Learn about connecting to your docs
+- [MCP Tools](./tools) — Available tools and their parameters
+- [Server Configuration](./server) — DocsServer options
+- [Caching](./caching) — Cache configuration
+- [CLI & Scaffolding](./cli) — Project scaffolding
+- [Custom Adapters](./custom-adapters) — Build your own source
+- [Fumadocs Setup](./fumadocs-setup) — Configure your Fumadocs site

--- a/docs/DocsPackage/server.md
+++ b/docs/DocsPackage/server.md
@@ -1,0 +1,122 @@
+---
+id: docs-package-server
+title: Server Configuration
+sidebar_position: 4
+---
+
+# DocsServer Configuration
+
+`DocsServer` is the convenience wrapper that ties together a `DocSource`, the pre-built tools, and the MCP protocol.
+
+## Basic Usage
+
+```typescript
+import { DocsServer, FumadocsRemoteSource } from "@mcp-framework/docs";
+
+const source = new FumadocsRemoteSource({
+  baseUrl: "https://docs.myapi.com",
+});
+
+const server = new DocsServer({
+  source,
+  name: "my-api-docs",
+  version: "1.0.0",
+});
+
+await server.start();
+```
+
+## Configuration
+
+```typescript
+interface DocsServerConfig {
+  source: DocSource;          // Documentation source (required)
+  name: string;               // Server name for MCP clients (required)
+  version: string;            // Server version (required)
+  transport?: TransportConfig; // Transport config (default: stdio)
+  tools?: {
+    search_docs?: boolean;     // Default: true
+    get_page?: boolean;        // Default: true
+    list_sections?: boolean;   // Default: true
+    custom?: MCPTool[];        // Additional custom tools
+  };
+}
+```
+
+## Disabling Tools
+
+```typescript
+const server = new DocsServer({
+  source,
+  name: "my-api-docs",
+  version: "1.0.0",
+  tools: {
+    list_sections: false,  // Disabled
+  },
+});
+```
+
+## Adding Custom Tools
+
+```typescript
+import { MCPTool } from "mcp-framework";
+import { z } from "zod";
+
+const schema = z.object({
+  endpoint: z.string().describe("API endpoint path"),
+});
+
+class GetSchemasTool extends MCPTool {
+  name = "get_schemas";
+  description = "Get request/response schemas for an API endpoint";
+  schema = schema;
+
+  async execute(input: z.infer<typeof schema>) {
+    return "Schema details...";
+  }
+}
+
+const server = new DocsServer({
+  source,
+  name: "my-api-docs",
+  version: "1.0.0",
+  tools: {
+    custom: [new GetSchemasTool()],
+  },
+});
+```
+
+## Environment-Driven Configuration
+
+Recommended for production deployments:
+
+```typescript
+const source = new FumadocsRemoteSource({
+  baseUrl: process.env.DOCS_BASE_URL || "https://docs.example.com",
+  headers: process.env.DOCS_API_KEY
+    ? { Authorization: `Bearer ${process.env.DOCS_API_KEY}` }
+    : undefined,
+});
+
+const server = new DocsServer({
+  source,
+  name: process.env.DOCS_SERVER_NAME || "my-docs",
+  version: process.env.npm_package_version || "1.0.0",
+});
+```
+
+## Lifecycle
+
+```typescript
+await server.start();  // Blocks until shutdown signal
+await server.stop();   // Stop programmatically
+```
+
+The server listens for `SIGINT` and `SIGTERM` and shuts down gracefully.
+
+## Accessing the Source
+
+```typescript
+const health = await server.source.healthCheck();
+console.log("Source healthy:", health.ok);
+```

--- a/docs/DocsPackage/sources.md
+++ b/docs/DocsPackage/sources.md
@@ -1,0 +1,151 @@
+---
+id: docs-package-sources
+title: Source Adapters
+sidebar_position: 2
+---
+
+# Source Adapters
+
+:::info Core Abstraction
+Source adapters are the heart of `@mcp-framework/docs`. Every documentation backend implements the `DocSource` interface, and all tools interact through it — never touching HTTP directly.
+:::
+
+## DocSource Interface
+
+```typescript
+interface DocSource {
+  name: string;
+  search(query: string, options?: DocSearchOptions): Promise<DocSearchResult[]>;
+  getPage(slug: string): Promise<DocPage | null>;
+  listSections(): Promise<DocSection[]>;
+  getIndex(): Promise<string>;
+  getFullContent(): Promise<string>;
+  healthCheck(): Promise<{ ok: boolean; message?: string }>;
+}
+```
+
+## FumadocsRemoteSource
+
+Purpose-built for [Fumadocs](https://fumadocs.vercel.app/) sites. Uses the native Orama search API for high-quality results, with automatic fallback to local text search.
+
+```typescript
+import { FumadocsRemoteSource } from "@mcp-framework/docs";
+
+const source = new FumadocsRemoteSource({
+  baseUrl: "https://docs.myapi.com",       // Required
+  searchEndpoint: "/api/search",            // Default
+  llmsTxtPath: "/llms.txt",                // Default
+  llmsFullTxtPath: "/llms-full.txt",       // Default
+  refreshInterval: 300_000,                // 5 min default
+  headers: {                                // Optional
+    Authorization: "Bearer your-token",
+  },
+});
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `baseUrl` | `string` | *required* | Base URL of your Fumadocs site |
+| `searchEndpoint` | `string` | `"/api/search"` | Fumadocs Orama search API path |
+| `llmsTxtPath` | `string` | `"/llms.txt"` | Path to the llms.txt index file |
+| `llmsFullTxtPath` | `string` | `"/llms-full.txt"` | Path to the full content file |
+| `mdxPathPrefix` | `string` | `"/"` | Prefix for individual .mdx page URLs |
+| `refreshInterval` | `number` | `300000` | Cache TTL in milliseconds |
+| `headers` | `Record<string, string>` | `undefined` | Custom HTTP headers |
+| `cache` | `Cache` | `MemoryCache` | Custom cache implementation |
+
+### How It Works
+
+| Method | Behavior |
+|--------|----------|
+| `search()` | Hits Fumadocs `/api/search` endpoint. Falls back to local text search on failure |
+| `getPage()` | Fetches `{baseUrl}/{slug}.mdx`. Falls back to `llms-full.txt` extraction |
+| `listSections()` | Parses `llms.txt` into a structured tree |
+| `healthCheck()` | HEAD request to `llms.txt` endpoint |
+
+## LlmsTxtSource
+
+Works with **any** documentation site that publishes `llms.txt` and `llms-full.txt`. Search is performed locally via text matching.
+
+```typescript
+import { LlmsTxtSource } from "@mcp-framework/docs";
+
+const source = new LlmsTxtSource({
+  baseUrl: "https://docs.myapi.com",
+  mdxPathPrefix: "/docs/",
+  refreshInterval: 300_000,
+});
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `baseUrl` | `string` | *required* | Base URL of your docs site |
+| `llmsTxtPath` | `string` | `"/llms.txt"` | Path to llms.txt |
+| `llmsFullTxtPath` | `string` | `"/llms-full.txt"` | Path to llms-full.txt |
+| `mdxPathPrefix` | `string` | `"/"` | Prefix for .mdx page fetching |
+| `refreshInterval` | `number` | `300000` | Cache TTL in milliseconds |
+| `headers` | `Record<string, string>` | `undefined` | Custom HTTP headers |
+| `cache` | `Cache` | `MemoryCache` | Custom cache implementation |
+
+### Local Search Algorithm
+
+1. Fetch and cache `llms-full.txt`
+2. Split into page blocks using `# Title (url)` headers
+3. Score each block by query term frequency (title matches weighted 3x)
+4. Normalize scores to 0–1
+5. Return top N results with snippet extraction
+
+## Choosing a Source
+
+| Your Setup | Recommended Adapter |
+|------------|-------------------|
+| Fumadocs with search API | `FumadocsRemoteSource` |
+| Fumadocs without search API | `LlmsTxtSource` |
+| Non-Fumadocs with llms.txt | `LlmsTxtSource` |
+| Custom backend | [Custom Adapter](./custom-adapters) |
+
+## Core Types
+
+### DocPage
+
+```typescript
+interface DocPage {
+  slug: string;          // URL-friendly identifier
+  url: string;           // Full URL to the page
+  title: string;         // Page title
+  description?: string;  // Brief description
+  content: string;       // Full markdown body
+  section?: string;      // Parent section name
+  lastModified?: string; // ISO 8601 date
+}
+```
+
+### DocSearchResult
+
+```typescript
+interface DocSearchResult {
+  slug: string;
+  url: string;
+  title: string;
+  description?: string;
+  snippet: string;       // Matched excerpt (max 200 chars)
+  section?: string;
+  score: number;         // Relevance 0–1
+}
+```
+
+### DocSection
+
+```typescript
+interface DocSection {
+  name: string;
+  slug: string;
+  url: string;
+  children: DocSection[];
+  pageCount: number;
+}
+```

--- a/docs/DocsPackage/tools.md
+++ b/docs/DocsPackage/tools.md
@@ -1,0 +1,115 @@
+---
+id: docs-package-tools
+title: Documentation Tools
+sidebar_position: 3
+---
+
+# Documentation Tools
+
+:::tip AI-Powered Documentation Access
+These three tools give AI agents everything they need to understand your API: search for relevant pages, read full content, and browse the documentation structure.
+:::
+
+All tools extend `MCPTool` from mcp-framework and use Zod schemas with `.describe()` on every field.
+
+## search_docs
+
+Search documentation by keyword or phrase. Returns a ranked list of matching pages with relevant excerpts.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | `string` | yes | Search keywords or phrase |
+| `section` | `string` | no | Filter results to a specific section |
+| `limit` | `number` | no | Max results (default 10, max 25) |
+
+### Example Output
+
+```
+1. **API Keys**
+   https://docs.myapi.com/docs/auth/api-keys
+   API keys are the simplest way to authenticate with MyAPI...
+   Section: Authentication
+
+2. **OAuth 2.0**
+   https://docs.myapi.com/docs/auth/oauth
+   OAuth 2.0 is recommended for applications that act on behalf of users.
+   Section: Authentication
+```
+
+### Token Budget
+
+Results are truncated to stay under ~**4,000 tokens** (~16,000 characters). If the budget is exceeded, trailing results are dropped with a count of omitted results.
+
+## get_page
+
+Retrieve the full markdown content of a documentation page.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `slug` | `string` | yes | Page slug or URL path |
+
+### Slug Normalization
+
+The tool automatically normalizes slugs:
+
+| Input | Normalized |
+|-------|-----------|
+| `/getting-started` | `getting-started` |
+| `getting-started/` | `getting-started` |
+| `/docs/getting-started` | `getting-started` |
+
+### Token Budget
+
+Content is truncated at ~**8,000 tokens** (~32,000 characters) with a notice appended if truncated.
+
+## list_sections
+
+Browse the documentation tree structure. Useful for discovering what's available before searching.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `section` | `string` | no | Filter to a section's children |
+
+### Example Output
+
+```
+- **Getting Started** (3 pages) [getting-started]
+- **Authentication** (1 pages) [authentication]
+  - **OAuth** (2 pages) [oauth]
+- **API Reference** (5 pages) [api-reference]
+```
+
+## Using Tools Directly
+
+You can use tool classes directly without DocsServer:
+
+```typescript
+import { SearchDocsTool, GetPageTool, ListSectionsTool } from "@mcp-framework/docs";
+import { LlmsTxtSource } from "@mcp-framework/docs/sources";
+
+const source = new LlmsTxtSource({ baseUrl: "https://docs.example.com" });
+
+const searchTool = new SearchDocsTool(source);
+const getPageTool = new GetPageTool(source);
+const listTool = new ListSectionsTool(source);
+
+// Call via MCP protocol
+const result = await searchTool.toolCall({
+  params: { name: "search_docs", arguments: { query: "authentication" } },
+});
+```
+
+## Error Handling
+
+All tools catch `DocSourceError` and return user-friendly messages:
+
+- **Search failures** → `"Search failed: {message}. Try again or use list_sections..."`
+- **Page not found** → `"Page not found: \"{slug}\". Use search_docs to find..."`
+- **Section not found** → Lists available sections as suggestions
+- **Source errors** → Descriptive message without stack traces


### PR DESCRIPTION
## Summary

- Adds a new **Docs Package** section to the documentation site covering `@mcp-framework/docs`
- 8 documentation pages: overview, source adapters, tools, server config, caching, CLI scaffolding, custom adapters, and Fumadocs setup guide
- Follows existing Docusaurus conventions (frontmatter, callouts, formatting)
- Auto-discovered by the existing autogenerated sidebar configuration

### New pages

| Page | Description |
|------|-------------|
| Overview | Package intro, quick start, architecture diagram |
| Source Adapters | FumadocsRemoteSource, LlmsTxtSource, core types |
| Documentation Tools | search_docs, get_page, list_sections parameters & behavior |
| Server Configuration | DocsServer options, custom tools, lifecycle |
| Caching | MemoryCache config, custom Cache interface, Redis example |
| CLI & Scaffolding | create-docs-server, MCP client config snippets |
| Custom Adapters | DocSource implementation, extending LlmsTxtSource, error handling |
| Fumadocs Setup | llms.txt routes, search API, troubleshooting |

## Test plan

- [ ] `npm run build` succeeds on the Docusaurus site
- [ ] New "Docs Package" section appears in the sidebar
- [ ] All internal links resolve correctly
- [ ] Code examples render with syntax highlighting


🤖 Generated with [Claude Code](https://claude.com/claude-code)