### PR TITLE
Add mcp-framework docs server page + fix package references

### DIFF
--- a/content/docs/docs-package/caching.mdx
+++ b/content/docs/docs-package/caching.mdx
@@ -1,11 +1,11 @@
 ---
 title: Caching
-description: Cache configuration and custom implementations for @mcp-framework/docs
+description: Cache configuration and custom implementations for @mcpframework/docs
 ---
 
 # Caching
 
-`@mcp-framework/docs` includes a built-in caching layer that reduces HTTP requests to your documentation site. All source adapters use caching automatically.
+`@mcpframework/docs` includes a built-in caching layer that reduces HTTP requests to your documentation site. All source adapters use caching automatically.
 
 ## Default Cache
 
@@ -24,7 +24,7 @@ The default `MemoryCache` is an in-memory LRU (Least Recently Used) cache with T
 ### Configuration
 
 ```typescript
-import { MemoryCache, LlmsTxtSource } from "@mcp-framework/docs";
+import { MemoryCache, LlmsTxtSource } from "@mcpframework/docs";
 
 const cache = new MemoryCache({
   maxEntries: 200,       // Default: 100
@@ -63,7 +63,7 @@ interface Cache {
 ### Example: Redis Cache
 
 ```typescript
-import { Cache, CacheStats } from "@mcp-framework/docs";
+import { Cache, CacheStats } from "@mcpframework/docs";
 import { createClient } from "redis";
 
 class RedisCache implements Cache {

--- a/content/docs/docs-package/cli.mdx
+++ b/content/docs/docs-package/cli.mdx
@@ -5,12 +5,12 @@ description: Scaffolding a ready-to-run documentation MCP server project with th
 
 # CLI & Project Scaffolding
 
-`@mcp-framework/docs` includes a CLI tool that scaffolds a ready-to-run documentation MCP server project.
+`@mcpframework/docs` includes a CLI tool that scaffolds a ready-to-run documentation MCP server project.
 
 ## Creating a Project
 
 ```bash
-npx create-docs-server my-api-docs
+npx create-docs-mcp my-api-docs
 ```
 
 This creates a project with the following structure:
@@ -19,7 +19,7 @@ This creates a project with the following structure:
 my-api-docs/
 ├── src/
 │   └── index.ts          # Pre-configured DocsServer with FumadocsRemoteSource
-├── package.json          # Dependencies on mcp-framework + @mcp-framework/docs
+├── package.json          # Dependencies on mcp-framework + @mcpframework/docs
 ├── tsconfig.json         # TypeScript configuration
 ├── .env.example          # DOCS_BASE_URL, optional DOCS_API_KEY
 ├── .gitignore
@@ -31,7 +31,7 @@ my-api-docs/
 ### `src/index.ts`
 
 ```typescript
-import { DocsServer, FumadocsRemoteSource } from "@mcp-framework/docs";
+import { DocsServer, FumadocsRemoteSource } from "@mcpframework/docs";
 
 const source = new FumadocsRemoteSource({
   baseUrl: process.env.DOCS_BASE_URL || "https://docs.example.com",
@@ -114,7 +114,7 @@ Add to MCP settings:
 The package includes a `SKILL.md.template` that you can customize to teach Claude Code how to approach integrations against your API. Copy it into your project:
 
 ```bash
-cp node_modules/@mcp-framework/docs/SKILL.md.template SKILL.md
+cp node_modules/@mcpframework/docs/SKILL.md.template SKILL.md
 # Edit SKILL.md with your API-specific patterns
 ```
 

--- a/content/docs/docs-package/custom-adapters.mdx
+++ b/content/docs/docs-package/custom-adapters.mdx
@@ -16,7 +16,7 @@ import {
   DocSearchResult,
   DocSection,
   DocSearchOptions,
-} from "@mcp-framework/docs";
+} from "@mcpframework/docs";
 
 class MyCustomSource implements DocSource {
   name = "my-custom-docs";
@@ -100,7 +100,7 @@ class MyCustomSource implements DocSource {
 ## Using Your Custom Source
 
 ```typescript
-import { DocsServer } from "@mcp-framework/docs";
+import { DocsServer } from "@mcpframework/docs";
 
 const source = new MyCustomSource();
 
@@ -118,7 +118,7 @@ server.start();
 If your site publishes `llms.txt` but also has a custom search API, extend `LlmsTxtSource` instead of implementing from scratch:
 
 ```typescript
-import { LlmsTxtSource, DocSearchResult, DocSearchOptions } from "@mcp-framework/docs";
+import { LlmsTxtSource, DocSearchResult, DocSearchOptions } from "@mcpframework/docs";
 
 class MyEnhancedSource extends LlmsTxtSource {
   override get name(): string {
@@ -165,7 +165,7 @@ import {
   DocFetchError,
   DocParseError,
   DocNotFoundError,
-} from "@mcp-framework/docs";
+} from "@mcpframework/docs";
 
 class MySource implements DocSource {
   async getPage(slug: string): Promise<DocPage | null> {

--- a/content/docs/docs-package/fumadocs-setup.mdx
+++ b/content/docs/docs-package/fumadocs-setup.mdx
@@ -1,11 +1,11 @@
 ---
 title: Fumadocs Setup Guide
-description: How to configure your Fumadocs documentation site to work with @mcp-framework/docs
+description: How to configure your Fumadocs documentation site to work with @mcpframework/docs
 ---
 
 # Fumadocs Setup Guide
 
-This guide explains how to configure your [Fumadocs](https://fumadocs.vercel.app/) documentation site to work with `@mcp-framework/docs`.
+This guide explains how to configure your [Fumadocs](https://fumadocs.vercel.app/) documentation site to work with `@mcpframework/docs`.
 
 ## Prerequisites
 
@@ -77,7 +77,7 @@ curl "https://docs.yoursite.com/api/search?query=getting+started"
 ## Step 4: Create Your MCP Server
 
 ```bash
-npx create-docs-server my-api-docs
+npx create-docs-mcp my-api-docs
 cd my-api-docs
 ```
 

--- a/content/docs/docs-package/mcp-framework-docs-server.mdx
+++ b/content/docs/docs-package/mcp-framework-docs-server.mdx
@@ -1,0 +1,99 @@
+---
+title: mcp-framework Docs Server
+description: A pre-built MCP server that gives AI agents access to the full mcp-framework documentation
+---
+
+# mcp-framework Docs Server
+
+`@mcpframework/mcp-framework-docs` is a ready-to-use MCP server that gives AI agents in Claude Code, Cursor, or any MCP client full access to the mcp-framework documentation. No configuration needed -- just add and go.
+
+## Add to Claude Code
+
+```bash
+claude mcp add mcp-framework-docs -- npx -y @mcpframework/mcp-framework-docs
+```
+
+That's it. Claude now has tools to search, browse, and read the entire mcp-framework docs.
+
+## Add to Claude Desktop
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "mcp-framework-docs": {
+      "command": "npx",
+      "args": ["-y", "@mcpframework/mcp-framework-docs"]
+    }
+  }
+}
+```
+
+## Add to Cursor
+
+Add to your MCP settings:
+
+```json
+{
+  "mcp-framework-docs": {
+    "command": "npx",
+    "args": ["-y", "@mcpframework/mcp-framework-docs"]
+  }
+}
+```
+
+## Available Tools
+
+Once connected, AI agents get three tools:
+
+| Tool | Description |
+|------|-------------|
+| `search_docs` | Search mcp-framework docs by keyword or phrase. Returns ranked results with excerpts. |
+| `get_page` | Retrieve the full markdown content of any documentation page. |
+| `list_sections` | Browse the documentation tree to discover available content. |
+
+## How It Works
+
+The server connects to `https://www.mcp-framework.com` and uses the `FumadocsRemoteSource` adapter to pull documentation via `llms.txt` and `llms-full.txt`. Search results are ranked locally with automatic fallback when the Orama search API is unavailable.
+
+```
+www.mcp-framework.com           Your MCP Client
++-------------------+           +---------------------------+
+| /llms.txt         |<--fetch---| search_docs("transport")  |
+| /llms-full.txt    |           | get_page("quickstart")    |
+| /api/search       |           | list_sections()           |
++-------------------+           +---------------------------+
+```
+
+## Source Code
+
+The server source is minimal -- the entire implementation is a single file:
+
+```typescript
+#!/usr/bin/env node
+import { DocsServer, FumadocsRemoteSource } from "@mcpframework/docs";
+
+const source = new FumadocsRemoteSource({
+  baseUrl: process.env.DOCS_BASE_URL || "https://www.mcp-framework.com",
+});
+
+const server = new DocsServer({
+  source,
+  name: "mcp-framework-docs",
+  version: "1.0.0",
+});
+
+server.start();
+```
+
+- **npm**: [@mcpframework/mcp-framework-docs](https://www.npmjs.com/package/@mcpframework/mcp-framework-docs)
+- **GitHub**: [QuantGeekDev/mcp-framework-docs-server](https://github.com/QuantGeekDev/mcp-framework-docs-server)
+
+## Build Your Own
+
+Want to create a similar docs server for your own project? See the [CLI page](./cli) to scaffold one in seconds:
+
+```bash
+npx create-docs-mcp my-api-docs
+```

--- a/content/docs/docs-package/meta.json
+++ b/content/docs/docs-package/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Docs Package",
-  "pages": ["overview", "sources", "tools", "server", "caching", "cli", "custom-adapters", "fumadocs-setup"]
+  "pages": ["overview", "mcp-framework-docs-server", "---", "sources", "tools", "server", "caching", "cli", "custom-adapters", "fumadocs-setup"]
 }

--- a/content/docs/docs-package/overview.mdx
+++ b/content/docs/docs-package/overview.mdx
@@ -1,11 +1,11 @@
 ---
-title: "@mcp-framework/docs Overview"
+title: "@mcpframework/docs Overview"
 description: A companion package that lets API providers spin up an MCP documentation server from their existing documentation site
 ---
 
-# @mcp-framework/docs Overview
+# @mcpframework/docs Overview
 
-`@mcp-framework/docs` is a companion package that lets API providers spin up an MCP documentation server from their existing documentation site. Developers connect from Claude Code, Cursor, or any MCP client and get tools to search, browse, and retrieve documentation -- enabling AI agents to write correct integration code on the first try.
+`@mcpframework/docs` is a companion package that lets API providers spin up an MCP documentation server from their existing documentation site. Developers connect from Claude Code, Cursor, or any MCP client and get tools to search, browse, and retrieve documentation -- enabling AI agents to write correct integration code on the first try.
 
 ## How It Works
 
@@ -14,7 +14,7 @@ The package provides:
 1. **Source Adapters** -- connect to your documentation backend (Fumadocs, any site with `llms.txt`)
 2. **MCP Tools** -- `search_docs`, `get_page`, `list_sections` that AI agents can call
 3. **DocsServer** -- a convenience wrapper that wires everything together
-4. **CLI Scaffolder** -- `npx create-docs-server my-api-docs` to generate a project in seconds
+4. **CLI Scaffolder** -- `npx create-docs-mcp my-api-docs` to generate a project in seconds
 
 ```
 Your Docs Site                    MCP Client (Claude Code, Cursor, etc.)
@@ -32,7 +32,7 @@ Your Docs Site                    MCP Client (Claude Code, Cursor, etc.)
 ## Quick Start
 
 ```typescript
-import { DocsServer, FumadocsRemoteSource } from "@mcp-framework/docs";
+import { DocsServer, FumadocsRemoteSource } from "@mcpframework/docs";
 
 const source = new FumadocsRemoteSource({
   baseUrl: "https://docs.myapi.com",
@@ -50,7 +50,7 @@ server.start();
 Or scaffold a complete project:
 
 ```bash
-npx create-docs-server my-api-docs
+npx create-docs-mcp my-api-docs
 cd my-api-docs
 cp .env.example .env
 # Edit .env with your docs site URL
@@ -59,11 +59,11 @@ npm run build && npm start
 
 ## Relationship to mcp-framework
 
-`@mcp-framework/docs` is a **consumer** of mcp-framework, not a fork. It imports `MCPTool` from mcp-framework and composes pre-built documentation tools on top of it. This keeps the core framework general-purpose while giving docs-server users a turnkey experience.
+`@mcpframework/docs` is a **consumer** of mcp-framework, not a fork. It imports `MCPTool` from mcp-framework and composes pre-built documentation tools on top of it. This keeps the core framework general-purpose while giving docs-server users a turnkey experience.
 
 ```
 mcp-framework (peer dependency)
-    +-- @mcp-framework/docs
+    +-- @mcpframework/docs
             +-- DocSource interface
             +-- Pre-built tools (SearchDocs, GetPage, ListSections)
             +-- DocsServer convenience class
@@ -80,8 +80,19 @@ Your documentation site must serve at least one of:
 
 See [Fumadocs Setup](./fumadocs-setup) for instructions on enabling these endpoints.
 
+## Pre-built: mcp-framework Docs Server
+
+We use `@mcpframework/docs` ourselves! The mcp-framework documentation is available as a ready-to-use MCP server -- no setup required:
+
+```bash
+claude mcp add mcp-framework-docs -- npx -y @mcpframework/mcp-framework-docs
+```
+
+See [mcp-framework Docs Server](./mcp-framework-docs-server) for full details.
+
 ## Next Steps
 
+- [mcp-framework Docs Server](./mcp-framework-docs-server) -- Use the pre-built server for mcp-framework docs
 - [Sources](./sources) -- Learn about source adapters
 - [Tools](./tools) -- Available MCP tools and their parameters
 - [Server Configuration](./server) -- DocsServer options

--- a/content/docs/docs-package/server.mdx
+++ b/content/docs/docs-package/server.mdx
@@ -10,7 +10,7 @@ description: Configuration options for the DocsServer convenience wrapper
 ## Basic Usage
 
 ```typescript
-import { DocsServer, FumadocsRemoteSource } from "@mcp-framework/docs";
+import { DocsServer, FumadocsRemoteSource } from "@mcpframework/docs";
 
 const source = new FumadocsRemoteSource({
   baseUrl: "https://docs.myapi.com",

--- a/content/docs/docs-package/sources.mdx
+++ b/content/docs/docs-package/sources.mdx
@@ -5,7 +5,7 @@ description: Documentation source adapters for connecting to different documenta
 
 # Source Adapters
 
-Source adapters are the central abstraction in `@mcp-framework/docs`. Every documentation backend implements the `DocSource` interface, and all tools interact through it -- never touching HTTP or filesystem directly.
+Source adapters are the central abstraction in `@mcpframework/docs`. Every documentation backend implements the `DocSource` interface, and all tools interact through it -- never touching HTTP or filesystem directly.
 
 ## DocSource Interface
 
@@ -28,7 +28,7 @@ Purpose-built for [Fumadocs](https://fumadocs.vercel.app/) sites. Leverages the 
 ### Configuration
 
 ```typescript
-import { FumadocsRemoteSource } from "@mcp-framework/docs";
+import { FumadocsRemoteSource } from "@mcpframework/docs";
 
 const source = new FumadocsRemoteSource({
   baseUrl: "https://docs.myapi.com",       // Required
@@ -73,7 +73,7 @@ Search is performed locally by splitting `llms-full.txt` into page blocks and sc
 ### Configuration
 
 ```typescript
-import { LlmsTxtSource } from "@mcp-framework/docs";
+import { LlmsTxtSource } from "@mcpframework/docs";
 
 const source = new LlmsTxtSource({
   baseUrl: "https://docs.myapi.com",

--- a/content/docs/docs-package/tools.mdx
+++ b/content/docs/docs-package/tools.mdx
@@ -1,11 +1,11 @@
 ---
 title: Documentation Tools
-description: MCP tools provided by @mcp-framework/docs for searching, browsing, and retrieving documentation
+description: MCP tools provided by @mcpframework/docs for searching, browsing, and retrieving documentation
 ---
 
 # Documentation Tools
 
-`@mcp-framework/docs` provides three MCP tools that extend `MCPTool` from mcp-framework. Each tool uses Zod schemas with mandatory `.describe()` on all fields.
+`@mcpframework/docs` provides three MCP tools that extend `MCPTool` from mcp-framework. Each tool uses Zod schemas with mandatory `.describe()` on all fields.
 
 ## search_docs
 
@@ -130,8 +130,8 @@ With `section: "Authentication"`:
 You can use the tool classes directly without DocsServer:
 
 ```typescript
-import { SearchDocsTool, GetPageTool, ListSectionsTool } from "@mcp-framework/docs";
-import { LlmsTxtSource } from "@mcp-framework/docs/sources";
+import { SearchDocsTool, GetPageTool, ListSectionsTool } from "@mcpframework/docs";
+import { LlmsTxtSource } from "@mcpframework/docs/sources";
 
 const source = new LlmsTxtSource({ baseUrl: "https://docs.example.com" });
 


### PR DESCRIPTION
## Summary
- Adds a new docs page for `@mcpframework/mcp-framework-docs` — the pre-built MCP server that gives AI agents access to mcp-framework documentation
- Fixes stale package name references: `@mcp-framework/docs` → `@mcpframework/docs` (matching the actual npm org)
- Fixes stale CLI name references: `create-docs-server` → `create-docs-mcp`
- Adds a "Pre-built" section to the overview page linking to the new server page

## New page covers
- One-command setup for Claude Code, Claude Desktop, and Cursor
- Available tools (search_docs, get_page, list_sections)
- How it works (architecture diagram)
- Source code and links to npm/GitHub

## Related
- npm: [@mcpframework/mcp-framework-docs](https://www.npmjs.com/package/@mcpframework/mcp-framework-docs)
- Repo: [QuantGeekDev/mcp-framework-docs-server](https://github.com/QuantGeekDev/mcp-framework-docs-server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)