### PR TITLE
feat: add OAuth 2.1 docs and update introduction

### DIFF
--- a/content/docs/authentication/meta.json
+++ b/content/docs/authentication/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Authentication",
-  "pages": ["overview"]
+  "pages": ["overview", "oauth"]
 }

--- a/content/docs/authentication/oauth.mdx
+++ b/content/docs/authentication/oauth.mdx
@@ -1,0 +1,568 @@
+---
+title: OAuth 2.1
+description: Production-ready OAuth 2.1 authentication with JWKS, token introspection, and support for Auth0, Okta, AWS Cognito, and Azure AD
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+
+# OAuth 2.1 Authentication
+
+MCP Framework supports OAuth 2.1 authentication per the MCP specification (2025-06-18), including Protected Resource Metadata ([RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)) and proper token validation with JWKS support.
+
+OAuth authentication works with both SSE and HTTP Stream transports and supports two validation strategies.
+
+<Callout title="Recommended for Production" type="info">
+OAuth 2.1 is the recommended authentication method for production deployments. For simpler use cases, see [API Key and JWT authentication](./overview).
+</Callout>
+
+## Quick Start
+
+```typescript
+import { MCPServer, OAuthAuthProvider } from "mcp-framework";
+
+const server = new MCPServer({
+  transport: {
+    type: "http-stream",
+    options: {
+      port: 8080,
+      auth: {
+        provider: new OAuthAuthProvider({
+          authorizationServers: ["https://auth.example.com"],
+          resource: "https://mcp.example.com",
+          validation: {
+            type: 'jwt',
+            jwksUri: "https://auth.example.com/.well-known/jwks.json",
+            audience: "https://mcp.example.com",
+            issuer: "https://auth.example.com"
+          }
+        })
+      }
+    }
+  }
+});
+
+await server.start();
+```
+
+### Testing Your Setup
+
+```bash
+# 1. Check metadata endpoint
+curl http://localhost:8080/.well-known/oauth-protected-resource
+
+# 2. Test without token (should return 401)
+curl -v -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'
+
+# 3. Test with valid token
+curl -X POST http://localhost:8080/mcp \
+  -H "Authorization: Bearer YOUR_TOKEN_HERE" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'
+```
+
+## Token Validation Strategies
+
+MCP Framework supports two token validation strategies, each with different trade-offs.
+
+### JWT Validation (Recommended for Performance)
+
+JWT validation fetches public keys from your authorization server's JWKS endpoint and validates tokens locally. This is the fastest option as it doesn't require a round-trip to the auth server for each request.
+
+```typescript
+import { MCPServer, OAuthAuthProvider } from "mcp-framework";
+
+const server = new MCPServer({
+  transport: {
+    type: "http-stream",
+    options: {
+      port: 8080,
+      auth: {
+        provider: new OAuthAuthProvider({
+          authorizationServers: [
+            process.env.OAUTH_AUTHORIZATION_SERVER
+          ],
+          resource: process.env.OAUTH_RESOURCE,
+          validation: {
+            type: 'jwt',
+            jwksUri: process.env.OAUTH_JWKS_URI,
+            audience: process.env.OAUTH_AUDIENCE,
+            issuer: process.env.OAUTH_ISSUER,
+            algorithms: ['RS256', 'ES256'] // Optional (default: ['RS256', 'ES256'])
+          }
+        }),
+        endpoints: {
+          initialize: true,  // Protect session initialization
+          messages: true     // Protect MCP messages
+        }
+      }
+    }
+  }
+});
+```
+
+**Environment Variables:**
+```bash
+OAUTH_AUTHORIZATION_SERVER=https://auth.example.com
+OAUTH_RESOURCE=https://mcp.example.com
+OAUTH_JWKS_URI=https://auth.example.com/.well-known/jwks.json
+OAUTH_AUDIENCE=https://mcp.example.com
+OAUTH_ISSUER=https://auth.example.com
+```
+
+**Performance characteristics:**
+- First request (cache miss): ~150-200ms
+- Cached requests: ~5-10ms
+- JWKS cache TTL: 15 minutes (configurable)
+
+### Token Introspection (Recommended for Centralized Control)
+
+Token introspection validates tokens by calling your authorization server's introspection endpoint ([RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662)). This provides centralized control and is useful when you need real-time token revocation.
+
+```typescript
+import { MCPServer, OAuthAuthProvider } from "mcp-framework";
+
+const server = new MCPServer({
+  transport: {
+    type: "sse",
+    options: {
+      auth: {
+        provider: new OAuthAuthProvider({
+          authorizationServers: [
+            process.env.OAUTH_AUTHORIZATION_SERVER
+          ],
+          resource: process.env.OAUTH_RESOURCE,
+          validation: {
+            type: 'introspection',
+            audience: process.env.OAUTH_AUDIENCE,
+            issuer: process.env.OAUTH_ISSUER,
+            introspection: {
+              endpoint: process.env.OAUTH_INTROSPECTION_ENDPOINT,
+              clientId: process.env.OAUTH_CLIENT_ID,
+              clientSecret: process.env.OAUTH_CLIENT_SECRET
+            }
+          }
+        })
+      }
+    }
+  }
+});
+```
+
+**Environment Variables:**
+```bash
+OAUTH_AUTHORIZATION_SERVER=https://auth.example.com
+OAUTH_RESOURCE=https://mcp.example.com
+OAUTH_AUDIENCE=https://mcp.example.com
+OAUTH_ISSUER=https://auth.example.com
+OAUTH_INTROSPECTION_ENDPOINT=https://auth.example.com/oauth/introspect
+OAUTH_CLIENT_ID=mcp-server
+OAUTH_CLIENT_SECRET=your-client-secret
+```
+
+**Performance characteristics:**
+- First request (cache miss): ~200-300ms
+- Cached requests: ~20-50ms
+- Cache TTL: 5 minutes (configurable)
+
+### Choosing a Strategy
+
+| Factor | JWT Validation | Token Introspection |
+|--------|---------------|---------------------|
+| **Performance** | Excellent (~5-10ms cached) | Good (~20-50ms cached) |
+| **Token Revocation** | Delayed (until expiry) | Immediate |
+| **Auth Server Load** | Very low | Moderate |
+| **Network Dependency** | Low (after key fetch) | High (every validation) |
+| **Best For** | High-performance APIs, short-lived tokens | Real-time revocation, compliance |
+
+**Recommendation:** Use JWT validation for most use cases. Use token introspection when you need real-time revocation.
+
+## Features
+
+- **RFC 9728 Compliance**: Automatic Protected Resource Metadata endpoint at `/.well-known/oauth-protected-resource`
+- **RFC 6750 WWW-Authenticate Headers**: Proper OAuth error responses with challenge headers
+- **JWKS Key Caching**: Public keys cached for 15 minutes (configurable)
+- **Token Introspection Caching**: Introspection results cached for 5 minutes (configurable)
+- **Security**: Tokens in query strings are automatically rejected
+- **Claims Extraction**: Access token claims in your tool handlers via `AuthResult`
+
+## Provider Integration
+
+The OAuth provider works with any RFC-compliant OAuth 2.1 authorization server.
+
+<Tabs items={['Auth0', 'Okta', 'AWS Cognito', 'Azure AD / Entra ID']}>
+<Tab value="Auth0">
+
+**Setup:**
+1. Create a Machine to Machine Application in [Auth0 Dashboard](https://manage.auth0.com/)
+2. Note your tenant domain, JWKS URI, and API audience
+
+```typescript
+import { MCPServer, OAuthAuthProvider } from "mcp-framework";
+
+const server = new MCPServer({
+  transport: {
+    type: "http-stream",
+    options: {
+      port: 8080,
+      auth: {
+        provider: new OAuthAuthProvider({
+          authorizationServers: [`https://${process.env.AUTH0_DOMAIN}`],
+          resource: process.env.AUTH0_AUDIENCE,
+          validation: {
+            type: 'jwt',
+            jwksUri: `https://${process.env.AUTH0_DOMAIN}/.well-known/jwks.json`,
+            audience: process.env.AUTH0_AUDIENCE,
+            issuer: `https://${process.env.AUTH0_DOMAIN}/`
+          }
+        })
+      }
+    }
+  }
+});
+```
+
+```bash title=".env"
+AUTH0_DOMAIN=your-tenant.auth0.com
+AUTH0_AUDIENCE=https://mcp.example.com
+```
+
+**Get a test token:**
+```bash
+curl --request POST \
+  --url https://your-tenant.auth0.com/oauth/token \
+  --header 'content-type: application/json' \
+  --data '{
+    "client_id": "YOUR_CLIENT_ID",
+    "client_secret": "YOUR_CLIENT_SECRET",
+    "audience": "https://mcp.example.com",
+    "grant_type": "client_credentials"
+  }'
+```
+
+</Tab>
+<Tab value="Okta">
+
+**Setup:**
+1. Create an API Services app in [Okta Admin Console](https://admin.okta.com/)
+2. Use the "default" authorization server or create a custom one
+
+```typescript
+import { MCPServer, OAuthAuthProvider } from "mcp-framework";
+
+const server = new MCPServer({
+  transport: {
+    type: "http-stream",
+    options: {
+      port: 8080,
+      auth: {
+        provider: new OAuthAuthProvider({
+          authorizationServers: [process.env.OKTA_ISSUER],
+          resource: process.env.OKTA_AUDIENCE,
+          validation: {
+            type: 'jwt',
+            jwksUri: `${process.env.OKTA_ISSUER}/v1/keys`,
+            audience: process.env.OKTA_AUDIENCE,
+            issuer: process.env.OKTA_ISSUER
+          }
+        })
+      }
+    }
+  }
+});
+```
+
+```bash title=".env"
+OKTA_ISSUER=https://your-domain.okta.com/oauth2/default
+OKTA_AUDIENCE=api://mcp-server
+```
+
+</Tab>
+<Tab value="AWS Cognito">
+
+**Setup:**
+1. Create a User Pool in [AWS Cognito Console](https://console.aws.amazon.com/cognito/)
+2. Configure an app client with client credentials flow
+3. Optionally create a Resource Server for custom scopes
+
+```typescript
+import { MCPServer, OAuthAuthProvider } from "mcp-framework";
+
+const server = new MCPServer({
+  transport: {
+    type: "http-stream",
+    options: {
+      port: 8080,
+      auth: {
+        provider: new OAuthAuthProvider({
+          authorizationServers: [process.env.COGNITO_ISSUER],
+          resource: process.env.COGNITO_AUDIENCE,
+          validation: {
+            type: 'jwt',
+            jwksUri: `${process.env.COGNITO_ISSUER}/.well-known/jwks.json`,
+            audience: process.env.COGNITO_AUDIENCE,
+            issuer: process.env.COGNITO_ISSUER
+          }
+        })
+      }
+    }
+  }
+});
+```
+
+```bash title=".env"
+COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_XXXXXXXXX
+COGNITO_AUDIENCE=1234567890abcdefghijklmnop
+```
+
+</Tab>
+<Tab value="Azure AD / Entra ID">
+
+**Setup:**
+1. Register an application in [Azure Portal](https://portal.azure.com/)
+2. Configure "Expose an API" with an Application ID URI
+3. Create a client secret under "Certificates & secrets"
+
+```typescript
+import { MCPServer, OAuthAuthProvider } from "mcp-framework";
+
+const server = new MCPServer({
+  transport: {
+    type: "http-stream",
+    options: {
+      port: 8080,
+      auth: {
+        provider: new OAuthAuthProvider({
+          authorizationServers: [
+            `https://login.microsoftonline.com/${process.env.AZURE_TENANT_ID}/v2.0`
+          ],
+          resource: process.env.AZURE_AUDIENCE,
+          validation: {
+            type: 'jwt',
+            jwksUri: `https://login.microsoftonline.com/${process.env.AZURE_TENANT_ID}/discovery/v2.0/keys`,
+            audience: process.env.AZURE_AUDIENCE,
+            issuer: `https://login.microsoftonline.com/${process.env.AZURE_TENANT_ID}/v2.0`
+          }
+        })
+      }
+    }
+  }
+});
+```
+
+```bash title=".env"
+AZURE_TENANT_ID=your-tenant-id
+AZURE_CLIENT_ID=your-client-id
+AZURE_CLIENT_SECRET=your-client-secret
+AZURE_AUDIENCE=api://mcp-server
+```
+
+</Tab>
+</Tabs>
+
+## Advanced Configuration
+
+### Custom Caching
+
+Adjust cache TTLs for your use case:
+
+```typescript
+import { JWTValidator, IntrospectionValidator } from "mcp-framework";
+
+// Custom JWT validator with shorter cache
+const jwtValidator = new JWTValidator({
+  jwksUri: "https://auth.example.com/.well-known/jwks.json",
+  audience: "https://mcp.example.com",
+  issuer: "https://auth.example.com",
+  cacheTTL: 600000 // 10 minutes (default: 15 minutes)
+});
+
+// Custom introspection validator with longer cache
+const introspectionValidator = new IntrospectionValidator({
+  endpoint: "https://auth.example.com/oauth/introspect",
+  clientId: "mcp-server",
+  clientSecret: process.env.CLIENT_SECRET,
+  cacheTTL: 600000 // 10 minutes (default: 5 minutes)
+});
+```
+
+### Multiple Authorization Servers
+
+```typescript
+const server = new MCPServer({
+  transport: {
+    type: "http-stream",
+    options: {
+      auth: {
+        provider: new OAuthAuthProvider({
+          authorizationServers: [
+            "https://primary-auth.example.com",
+            "https://partner-auth.example.com"
+          ],
+          resource: "https://mcp.example.com",
+          validation: {
+            type: 'jwt',
+            jwksUri: "https://primary-auth.example.com/.well-known/jwks.json",
+            audience: "https://mcp.example.com",
+            issuer: "https://primary-auth.example.com"
+          }
+        })
+      }
+    }
+  }
+});
+```
+
+### Per-Endpoint Authentication
+
+```typescript
+const server = new MCPServer({
+  transport: {
+    type: "http-stream",
+    options: {
+      auth: {
+        provider: new OAuthAuthProvider({ /* ... */ }),
+        endpoints: {
+          initialize: true,   // Require auth for session creation
+          messages: true       // Require auth for MCP messages
+        }
+      }
+    }
+  }
+});
+```
+
+## Security Best Practices
+
+- **Always use HTTPS in production** — OAuth tokens should never be transmitted over unencrypted connections
+- **Validate audience claims** — Prevents token reuse across different services
+- **Use short-lived tokens** — Reduces risk if tokens are compromised (15-60 minutes recommended)
+- **Enable token introspection caching** — Reduces load on authorization server while maintaining security
+- **Monitor token errors** — Track failed authentication attempts for security insights
+- **Never store tokens in localStorage** — Use secure, httpOnly cookies or secure storage
+
+## Migration Guide
+
+### From JWT Provider to OAuth
+
+```typescript
+// Before (JWT Provider)
+import { MCPServer, JWTAuthProvider } from "mcp-framework";
+
+const server = new MCPServer({
+  transport: {
+    type: "sse",
+    options: {
+      auth: {
+        provider: new JWTAuthProvider({
+          secret: process.env.JWT_SECRET,
+          algorithms: ["HS256"]
+        })
+      }
+    }
+  }
+});
+
+// After (OAuth Provider)
+import { MCPServer, OAuthAuthProvider } from "mcp-framework";
+
+const server = new MCPServer({
+  transport: {
+    type: "sse",
+    options: {
+      auth: {
+        provider: new OAuthAuthProvider({
+          authorizationServers: [process.env.OAUTH_ISSUER],
+          resource: process.env.OAUTH_RESOURCE,
+          validation: {
+            type: 'jwt',
+            jwksUri: process.env.OAUTH_JWKS_URI,
+            audience: process.env.OAUTH_AUDIENCE,
+            issuer: process.env.OAUTH_ISSUER
+          }
+        })
+      }
+    }
+  }
+});
+```
+
+**Key differences:**
+- OAuth uses asymmetric keys (RS256/ES256) instead of symmetric (HS256)
+- Tokens must come from a proper authorization server
+- Automatic metadata endpoint at `/.well-known/oauth-protected-resource`
+- Better security with audience validation
+
+### From API Key to OAuth
+
+```typescript
+// Before (API Key)
+import { MCPServer, APIKeyAuthProvider } from "mcp-framework";
+
+const server = new MCPServer({
+  transport: {
+    type: "http-stream",
+    options: {
+      auth: {
+        provider: new APIKeyAuthProvider({
+          keys: [process.env.API_KEY]
+        })
+      }
+    }
+  }
+});
+
+// After (OAuth)
+import { MCPServer, OAuthAuthProvider } from "mcp-framework";
+
+const server = new MCPServer({
+  transport: {
+    type: "http-stream",
+    options: {
+      auth: {
+        provider: new OAuthAuthProvider({
+          authorizationServers: [process.env.OAUTH_ISSUER],
+          resource: process.env.OAUTH_RESOURCE,
+          validation: {
+            type: 'jwt',
+            jwksUri: process.env.OAUTH_JWKS_URI,
+            audience: process.env.OAUTH_AUDIENCE,
+            issuer: process.env.OAUTH_ISSUER
+          }
+        })
+      }
+    }
+  }
+});
+```
+
+## Troubleshooting
+
+### Common Issues
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "Invalid token signature" | JWKS keys don't match token | Verify JWKS endpoint returns correct keys; check `kid` in token header |
+| "Token audience invalid" | Token `aud` claim mismatch | Ensure `audience` config matches the token's `aud` claim |
+| "Token has expired" | Token `exp` is in the past | Request a new token; check system clock sync |
+| "JWKS endpoint unreachable" | Network or wrong URI | Test endpoint with `curl`; check DNS and firewall |
+| "Token introspection failed" | Bad credentials or endpoint | Verify `clientId`, `clientSecret`, and introspection endpoint URL |
+
+### Debug Logging
+
+```bash
+# Enable debug logging
+MCP_DEBUG_CONSOLE=true node dist/index.js
+
+# Enable file logging
+MCP_ENABLE_FILE_LOGGING=true MCP_LOG_DIRECTORY=logs node dist/index.js
+```
+
+Look for OAuth-related log messages:
+```
+[INFO] OAuthAuthProvider initialized with JWT validation
+[DEBUG] Token claims - sub: user-123, scope: read write
+[ERROR] OAuth authentication failed: Token has expired
+```

--- a/content/docs/authentication/overview.mdx
+++ b/content/docs/authentication/overview.mdx
@@ -1,11 +1,17 @@
 ---
 title: Authentication
-description: Securing MCP server endpoints with API Key and JWT authentication providers
+description: Securing MCP server endpoints with OAuth 2.1, API Key, and JWT authentication providers
 ---
+
+import { Callout } from 'fumadocs-ui/components/callout';
 
 # Authentication
 
 The MCP Framework provides built-in authentication support through various authentication providers. This allows you to secure your MCP server endpoints and ensure only authorized clients can access your tools and resources.
+
+<Callout title="OAuth 2.1 Recommended" type="info">
+For production deployments, we recommend [OAuth 2.1 authentication](./oauth) which supports JWKS validation, token introspection, and works with Auth0, Okta, AWS Cognito, Azure AD, and any RFC-compliant provider.
+</Callout>
 
 ## Available Authentication Providers
 
@@ -14,7 +20,7 @@ The MCP Framework provides built-in authentication support through various authe
 The API Key authentication provider allows you to secure your endpoints using API keys. This is useful for simple authentication scenarios where you want to control access using predefined keys.
 
 ```typescript
-import { APIKeyAuthProvider } from "@modelcontextprotocol/mcp-framework";
+import { APIKeyAuthProvider } from "mcp-framework";
 
 const authProvider = new APIKeyAuthProvider({
   keys: ["your-api-key-1", "your-api-key-2"],
@@ -32,7 +38,7 @@ X-API-Key: your-api-key-1
 The JWT authentication provider enables token-based authentication using JSON Web Tokens. This is suitable for more complex authentication scenarios where you need to include user information or other claims in the token.
 
 ```typescript
-import { JWTAuthProvider } from "@modelcontextprotocol/mcp-framework";
+import { JWTAuthProvider } from "mcp-framework";
 
 const authProvider = new JWTAuthProvider({
   secret: "your-jwt-secret",
@@ -52,7 +58,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
 You can configure authentication when setting up your SSE transport:
 
 ```typescript
-import { MCPServer, APIKeyAuthProvider } from "@modelcontextprotocol/mcp-framework";
+import { MCPServer, APIKeyAuthProvider } from "mcp-framework";
 
 const server = new MCPServer({
   transport: {

--- a/content/docs/introduction.mdx
+++ b/content/docs/introduction.mdx
@@ -24,8 +24,8 @@ You can build a MCP server with mcp-framework in under 5 minutes! [Follow the qu
 - **Tool Support**: Create custom tools that extend AI model capabilities
 - **Resource Management**: Handle external data sources and APIs
 - **Prompt Templates**: Define reusable prompt templates
-- **Multiple Transports**: Support for both STDIO and SSE (Server-Sent Events) communication
-- **Authentication**: Built-in JWT and API Key authentication for SSE transport
+- **Multiple Transports**: Support for STDIO, HTTP Stream (recommended), and SSE communication
+- **Authentication**: Built-in OAuth 2.1 (recommended), JWT, and API Key authentication
 - **Use the power of Typescript**: Full TypeScript support with type safety
 - **CLI Tool**: Easy project scaffolding and component creation
 - **Fast Development**: Elegant and fast development cycles
@@ -66,7 +66,8 @@ Communication layers that:
 - Handle client-server communication
 - Support different use cases:
   - **STDIO**: Perfect for CLI tools and local integrations
-  - **SSE**: Ideal for web applications with optional authentication
+  - **HTTP Stream** (Recommended): Modern transport for web applications with authentication, session management, and stream resumability
+  - **SSE** (Deprecated): Legacy transport, replaced by HTTP Stream
 
 The framework handles all communication between your server and AI models, following the Model Context Protocol specification.
 
@@ -77,7 +78,7 @@ The framework handles all communication between your server and AI models, follo
 - Developing specialized AI assistants
 - Extending AI capabilities with external services
 - Building enterprise AI solutions
-- Creating web-based AI tools (using SSE transport)
-- Developing secure AI services with authentication
+- Creating web-based AI tools (using HTTP Stream transport)
+- Developing secure AI services with OAuth 2.1 authentication
 
 Ready to get started? Head to the [Installation](./installation) guide to begin building your first MCP server, or learn more about our [transport options](transports/overview).


### PR DESCRIPTION
## Summary
- Add comprehensive OAuth 2.1 authentication page (`authentication/oauth.mdx`) covering JWT validation, token introspection, provider integration tabs (Auth0, Okta, AWS Cognito, Azure AD), advanced configuration, migration guides, security best practices, and troubleshooting
- Update introduction page to mention HTTP Stream as recommended transport, OAuth 2.1 as recommended auth, and mark SSE as deprecated
- Add OAuth 2.1 callout to the existing auth overview page pointing users to the new page
- Fix incorrect import paths from `@modelcontextprotocol/mcp-framework` to `mcp-framework` in auth overview examples

## Test plan
- [ ] Verify OAuth page renders correctly with Fumadocs tabs and callouts
- [ ] Verify navigation includes the new OAuth page under Authentication
- [ ] Verify introduction page accurately reflects current transport and auth options
- [ ] Verify all code examples use correct import paths (`mcp-framework`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)