### PR TITLE
docs: MCP 2025-11-25 spec compliance documentation

### DIFF
--- a/content/docs/authentication/overview.mdx
+++ b/content/docs/authentication/overview.mdx
@@ -47,6 +47,39 @@ Clients must include the JWT token in the Authorization header:
 Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
 ```
 
+### OAuth 2.1 Authentication
+
+For production deployments, the framework supports OAuth 2.1 authentication per MCP spec 2025-11-25 with both JWT validation and token introspection strategies. This integrates with standard OAuth providers such as Auth0, Okta, AWS Cognito, and Azure AD/Entra ID.
+
+```typescript
+import { MCPServer, OAuthAuthProvider } from "mcp-framework";
+
+const server = new MCPServer({
+  transport: {
+    type: "http-stream",
+    auth: {
+      provider: new OAuthAuthProvider({
+        authorizationServers: ["https://auth.example.com"],
+        resource: "https://mcp.example.com",
+        validation: {
+          type: "jwt",
+          jwksUri: "https://auth.example.com/.well-known/jwks.json",
+          audience: "https://mcp.example.com",
+          issuer: "https://auth.example.com",
+        },
+      }),
+    },
+  },
+});
+```
+
+The OAuth provider supports two validation strategies:
+
+- **JWT validation** — Validates tokens locally using public keys fetched from a JWKS endpoint. Fast (~5-10ms with cached keys) and suitable when token revocation latency is acceptable.
+- **Token introspection** — Validates tokens by calling the authorization server's introspection endpoint (RFC 7662). Slower (~20-50ms with caching) but supports immediate token revocation.
+
+Key security features include automatic rejection of tokens in query strings, audience validation to prevent token reuse across services, and `WWW-Authenticate` challenges per RFC 6750. The provider also serves a `/.well-known/oauth-protected-resource` metadata endpoint (RFC 9728) automatically when configured on SSE or HTTP Stream transports.
+
 ## Configuring Authentication
 
 You can configure authentication when setting up your SSE transport:

--- a/content/docs/introduction.mdx
+++ b/content/docs/introduction.mdx
@@ -21,14 +21,18 @@ You can build a MCP server with mcp-framework in under 5 minutes! [Follow the qu
 
 ## Key Features
 
-- **Tool Support**: Create custom tools that extend AI model capabilities
-- **Resource Management**: Handle external data sources and APIs
-- **Prompt Templates**: Define reusable prompt templates
-- **Multiple Transports**: Support for both STDIO and SSE (Server-Sent Events) communication
-- **Authentication**: Built-in JWT and API Key authentication for SSE transport
-- **Use the power of Typescript**: Full TypeScript support with type safety
+- **Tool Support**: Create custom tools with annotations, structured output schemas, and rich content types (text, images, audio, resource links)
+- **Resource Management**: Handle external data sources with title, icons, size, and annotation metadata
+- **Prompt Templates**: Define reusable prompt templates with display metadata
+- **Multiple Transports**: STDIO, HTTP Stream (recommended), and SSE with security features (origin validation, localhost binding)
+- **Authentication**: Built-in API Key, JWT, and OAuth 2.1 authentication
+- **Protocol Utilities**: Progress tracking, cancellation, structured logging, and elicitation (request user input)
+- **Sampling**: Request LLM completions from tools, with tool-use support for agentic workflows
+- **Roots Support**: Query client filesystem boundaries for safe file operations
+- **Tasks (Experimental)**: Async tool execution with polling and deferred result retrieval
+- **Full TypeScript**: Type-safe schemas with Zod, full autocompletion
 - **CLI Tool**: Easy project scaffolding and component creation
-- **Fast Development**: Elegant and fast development cycles
+- **MCP 2025-11-25 Compliant**: Up-to-date with the latest Model Context Protocol specification
 
 ## How It Works
 
@@ -38,35 +42,39 @@ MCP Framework provides four main components:
 
 Functions that AI models can invoke to:
 
-- Fetch data from APIs
-- Transform data
-- Perform computations
-- Interact with external services
+- Fetch data from APIs and transform data
+- Perform computations and interact with external services
+- Return rich content: text, images, audio, resource links
+- Report progress, check for cancellation, and send log messages
+- Request user input via elicitation and query filesystem roots
 
 ### 2. Resources
 
 Data sources that can be:
 
-- Read by the AI model
-- Subscribed to for updates
-- Used to provide context
+- Read by the AI model with rich metadata (title, icons, size, annotations)
+- Subscribed to for real-time updates
+- Used to provide context with audience and priority hints
 
 ### 3. Prompts
 
 Template systems that:
 
-- Define reusable conversation flows
-- Provide structured context
-- Guide model interactions
+- Define reusable conversation flows with display metadata
+- Provide structured context with validated arguments
+- Guide model interactions with icons and descriptions
 
 ### 4. Transports
 
 Communication layers that:
 
-- Handle client-server communication
+- Handle client-server communication securely
 - Support different use cases:
   - **STDIO**: Perfect for CLI tools and local integrations
-  - **SSE**: Ideal for web applications with optional authentication
+  - **HTTP Stream** (recommended): Modern HTTP-based transport with streaming, sessions, and auth
+  - **SSE**: Legacy web transport (deprecated, use HTTP Stream instead)
+- Origin validation for DNS rebinding protection
+- Localhost-only binding by default for security
 
 The framework handles all communication between your server and AI models, following the Model Context Protocol specification.
 

--- a/content/docs/prompts/overview.mdx
+++ b/content/docs/prompts/overview.mdx
@@ -62,6 +62,46 @@ class GreetingPrompt extends MCPPrompt<GreetingPromptInput> {
 }
 ```
 
+## Title and Icons
+
+Prompts now support display metadata per MCP spec 2025-11-25, allowing clients to render richer UIs such as prompt pickers and menus.
+
+```typescript
+import { MCPPrompt } from "mcp-framework";
+import { z } from "zod";
+
+class ReportPrompt extends MCPPrompt<{ topic: string }> {
+  name = "generate_report";
+  title = "Report Generator";  // Human-readable display name
+  description = "Generate a report on a given topic";
+  icons = [{ src: "https://example.com/report-icon.png", mimeType: "image/png" }];
+
+  schema = {
+    topic: {
+      type: z.string(),
+      description: "Topic to generate a report about",
+      required: true,
+    },
+  };
+
+  async generateMessages(args: { topic: string }) {
+    return [{
+      role: "user",
+      content: { type: "text", text: `Generate a detailed report about: ${args.topic}` }
+    }];
+  }
+}
+```
+
+### Field Reference
+
+- **`title`** — Optional human-readable name for display in client UIs (e.g., prompt picker dialogs). Falls back to `name` if not set.
+- **`icons`** — Optional array of icon objects for client UI rendering. Each object has `src` (URL or data URI), optional `mimeType`, and optional `sizes`.
+
+<Callout title="Display Only" type="info">
+Both `title` and `icons` are purely for display purposes. They do not affect prompt behavior or message generation.
+</Callout>
+
 ## Creating Prompts
 
 ### Using the CLI

--- a/content/docs/resources/overview.mdx
+++ b/content/docs/resources/overview.mdx
@@ -165,6 +165,78 @@ class StockTickerResource extends MCPResource {
 }
 ```
 
+## Title, Icons, Size, and Annotations
+
+Resources now support additional metadata fields per MCP spec 2025-11-25, enabling richer display in client UIs and providing behavioral hints to clients.
+
+```typescript
+import { MCPResource } from "mcp-framework";
+
+class ProjectResource extends MCPResource {
+  uri = "resource://project/readme";
+  name = "README";
+  title = "Project Documentation";  // Human-readable display name
+  description = "Project README file";
+  mimeType = "text/markdown";
+  size = 4096;  // Optional: size in bytes
+
+  // Optional: icons for client UI
+  icons = [{ src: "https://example.com/doc-icon.png", mimeType: "image/png" }];
+
+  // Optional: annotations for client behavior hints
+  resourceAnnotations = {
+    audience: ["user", "assistant"],  // Who this is for
+    priority: 0.8,                    // 0.0 (optional) to 1.0 (critical)
+    lastModified: "2025-01-12T15:00:58Z",
+  };
+
+  async read() {
+    return [{
+      uri: this.uri,
+      mimeType: this.mimeType,
+      text: "# My Project\n\nProject documentation...",
+    }];
+  }
+}
+```
+
+### Field Reference
+
+- **`title`** — Optional human-readable name for display in client UIs. Falls back to `name` if not set.
+- **`icons`** — Optional array of icon objects with `src` (URL or data URI), optional `mimeType`, and optional `sizes`.
+- **`size`** — Optional size in bytes. This is a hint; actual content returned from `read()` may differ.
+- **`resourceAnnotations`** — Optional metadata hints for client behavior:
+  - `audience` — Array of `"user"` and/or `"assistant"` indicating who the resource is intended for.
+  - `priority` — Number from 0.0 to 1.0 indicating importance (1.0 = most important, 0.0 = least important).
+  - `lastModified` — ISO 8601 timestamp of the last modification.
+
+<Callout title="Annotations Are Hints" type="info">
+Annotations are purely informational. Clients may use them for display ordering, filtering, or UI hints, but they do not enforce any behavior.
+</Callout>
+
+### Resource Templates with Metadata
+
+When using resource templates, `title` and `icons` defined on the class also apply to the template definition:
+
+```typescript
+class FileResource extends MCPResource {
+  uri = "resource://files/{path}";
+  name = "Project Files";
+  title = "Project File Browser";
+  icons = [{ src: "https://example.com/file-icon.png", mimeType: "image/png" }];
+
+  protected template = {
+    uriTemplate: "resource://files/{path}",
+    description: "Access project files",
+  };
+  // title and icons on the class also apply to the template definition
+
+  async read() {
+    // ...
+  }
+}
+```
+
 ## Best Practices
 
 1. **URI Naming**

--- a/content/docs/server-configuration.mdx
+++ b/content/docs/server-configuration.mdx
@@ -133,6 +133,8 @@ The server also handles SIGINT signals (Ctrl+C) for graceful shutdown.
 
 ## Logging
 
+### Framework Logging
+
 The server uses a built-in logger that can be imported and configured:
 
 ```typescript
@@ -144,6 +146,8 @@ logger.info("Info message");
 logger.warn("Warning message");
 logger.error("Error message");
 ```
+
+This is the framework's internal logging system, controlled via environment variables (`MCP_ENABLE_FILE_LOGGING`, `MCP_LOG_DIRECTORY`, `MCP_DEBUG_CONSOLE`). It writes to stderr and optionally to log files.
 
 ## Best Practices
 
@@ -173,32 +177,84 @@ logger.error("Error message");
    - Implement proper cleanup in tools
    - Monitor server resources
 
+### MCP Protocol Logging
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+The server can declare the MCP `logging` capability, which allows tools to send structured log messages to connected clients over the transport:
+
+```typescript
+const server = new MCPServer({
+  logging: true,  // Enable MCP protocol logging capability
+  // ...
+});
+```
+
+When enabled:
+
+- The server declares the `logging` capability during initialization, signaling to clients that it supports the MCP logging protocol.
+- Clients can control the minimum log level by sending `logging/setLevel` requests.
+- Tools can send log messages to the client via `this.log(level, data)` inside the `execute` method.
+- Log levels follow RFC 5424 severity: `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`.
+- The default threshold is `warning` -- only messages at `warning` level and above are sent to the client until it explicitly changes the level via `logging/setLevel`.
+
+<Callout type="info">
+MCP protocol logging is separate from the framework's internal file/stderr logging. Framework logs (via the `logger` import) go to stderr and log files. MCP protocol logs (via `this.log()` in tools) are sent to the connected client over the MCP transport.
+</Callout>
+
+## Tasks (Experimental)
+
+Enable asynchronous tool execution with polling and deferred result retrieval:
+
+```typescript
+const server = new MCPServer({
+  tasks: {
+    enabled: true,
+    defaultTtl: 300000,        // Task lifetime in ms (default: 5 minutes)
+    defaultPollInterval: 5000,  // Suggested poll interval in ms (default: 5 seconds)
+    maxTasks: 100,              // Maximum concurrent tasks (default: 100)
+  },
+});
+```
+
+When enabled:
+- The server declares the `tasks` capability with `list`, `cancel`, and `requests.tools.call` support
+- Tools opt in via `execution: { taskSupport: 'optional' }` on the tool class
+- When a client includes a `task` field in `tools/call`, the server creates a task, executes the tool in the background, and immediately returns a task ID
+- Clients poll via `tasks/get` and retrieve results via `tasks/result`
+- Tasks expire after the configured TTL
+
+This is an **experimental** feature from MCP specification 2025-11-25. See [Advanced Tool Features](/docs/tools/advanced-features) for tool-side configuration.
+
 ## Example Configuration
 
 Here's a complete example with all configuration options:
 
 ```typescript
-import { MCPServer, APIKeyAuthProvider } from "@modelcontextprotocol/mcp-framework";
+import { MCPServer, APIKeyAuthProvider } from "mcp-framework";
 
 const server = new MCPServer({
   name: "my-mcp-server",
   version: "1.0.0",
   basePath: "./dist",
+  logging: true,  // Enable protocol logging
+  tasks: {        // Enable async tasks (experimental)
+    enabled: true,
+    defaultTtl: 300000,
+    maxTasks: 100,
+  },
   transport: {
-    type: "sse",
+    type: "http-stream",
     options: {
       port: 8080,
-      endpoint: "/sse",
-      messageEndpoint: "/messages",
-      maxMessageSize: "4mb",
-      headers: {
-        "X-Custom-Header": "value"
-      },
+      host: "127.0.0.1",      // Default: localhost only (use "0.0.0.0" for Docker)
+      endpoint: "/mcp",
+      responseMode: "stream",
       cors: {
-        allowOrigin: "*",
-        allowMethods: "GET, POST, OPTIONS",
-        allowHeaders: "Content-Type, Authorization, x-api-key",
-        exposeHeaders: "Content-Type, Authorization, x-api-key",
+        allowedOrigins: ["http://localhost:3000"],  // Origin validation
+        allowMethods: "GET, POST, DELETE, OPTIONS",
+        allowHeaders: "Content-Type, Authorization, x-api-key, Mcp-Session-Id",
+        exposeHeaders: "Content-Type, Authorization, Mcp-Session-Id",
         maxAge: "86400"
       },
       auth: {

--- a/content/docs/tools/advanced-features.mdx
+++ b/content/docs/tools/advanced-features.mdx
@@ -1,0 +1,337 @@
+---
+title: Advanced Tool Features
+description: Progress tracking, cancellation, logging, elicitation, roots, sampling with tools, structured content, and tasks
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+# Advanced Tool Features
+
+This page covers advanced capabilities available to tools in MCP Framework, including structured output, progress reporting, cancellation, logging, elicitation, roots access, sampling, and task support.
+
+## Structured Content & Output Schemas
+
+Tools can declare an output schema to return strongly-typed structured JSON. When an `outputSchemaShape` is defined, the framework automatically wraps the return value in `structuredContent` and provides a `text` fallback for clients that do not support structured output.
+
+```typescript
+import { MCPTool } from "mcp-framework";
+import { z } from "zod";
+
+class WeatherTool extends MCPTool {
+  name = "weather_data";
+  description = "Get structured weather data";
+  schema = z.object({ city: z.string().describe("City name") });
+  outputSchemaShape = z.object({
+    temperature: z.number().describe("Temperature in celsius"),
+    conditions: z.string().describe("Weather conditions"),
+  });
+
+  async execute(input: { city: string }) {
+    return { temperature: 22.5, conditions: "Sunny" };
+    // Framework automatically adds structuredContent + text fallback
+  }
+}
+```
+
+When the tool returns a plain object and `outputSchemaShape` is set, the framework validates the return value against the schema and sends it as `structuredContent`. Clients that understand structured output receive typed JSON; others fall back to a text representation.
+
+## Progress Tracking
+
+For long-running operations, report incremental progress to the client using `this.reportProgress()`. This lets clients display progress bars or status indicators.
+
+```typescript
+import { MCPTool, MCPInput } from "mcp-framework";
+import { z } from "zod";
+
+class BatchProcessor extends MCPTool {
+  name = "batch_process";
+  description = "Process a batch of items with progress reporting";
+
+  schema = z.object({
+    batchId: z.string().describe("Batch identifier"),
+  });
+
+  async execute(input: MCPInput<this>) {
+    const items = await getItems(input.batchId);
+
+    for (let i = 0; i < items.length; i++) {
+      await this.reportProgress(i + 1, items.length, `Processing item ${i + 1}`);
+      await processItem(items[i]);
+    }
+
+    return "Done";
+  }
+}
+```
+
+The `reportProgress` method accepts three arguments:
+- `current` — The current step number
+- `total` — The total number of steps
+- `message` (optional) — A human-readable status message
+
+## Cancellation
+
+Tools can check for client-initiated cancellation by inspecting `this.abortSignal`. This is especially useful for long-running or iterative operations where early termination saves resources.
+
+```typescript
+import { MCPTool, MCPInput } from "mcp-framework";
+import { z } from "zod";
+
+class LargeExportTool extends MCPTool {
+  name = "large_export";
+  description = "Export a large dataset with cancellation support";
+
+  schema = z.object({
+    dataset: z.string().describe("Dataset name"),
+  });
+
+  async execute(input: MCPInput<this>) {
+    const items = await loadDataset(input.dataset);
+
+    for (const item of items) {
+      if (this.abortSignal?.aborted) {
+        return "Operation cancelled";
+      }
+      await exportItem(item);
+    }
+
+    return "Complete";
+  }
+}
+```
+
+<Callout title="Graceful Cancellation" type="info">
+Always handle cancellation gracefully by cleaning up any resources (open files, database connections, etc.) before returning. The abort signal is cooperative, so the tool must check it explicitly.
+</Callout>
+
+## Logging
+
+Send structured log messages to the client during tool execution using `this.log()`. This is useful for debugging, auditing, and providing visibility into tool behavior.
+
+```typescript
+import { MCPTool, MCPInput } from "mcp-framework";
+import { z } from "zod";
+
+class DataPipeline extends MCPTool {
+  name = "data_pipeline";
+  description = "Run a data processing pipeline with logging";
+
+  schema = z.object({
+    source: z.string().describe("Data source identifier"),
+  });
+
+  async execute(input: MCPInput<this>) {
+    await this.log('info', 'Starting data processing');
+    await this.log('debug', { step: 1, input });
+
+    const data = await fetchData(input.source);
+    await this.log('info', `Fetched ${data.length} records`);
+
+    const result = await transformData(data);
+    await this.log('info', 'Processing complete');
+
+    return result;
+  }
+}
+```
+
+Log levels follow RFC 5424 severity levels:
+
+| Level | Description |
+|---|---|
+| `debug` | Detailed debugging information |
+| `info` | Informational messages |
+| `notice` | Normal but significant events |
+| `warning` | Warning conditions |
+| `error` | Error conditions |
+| `critical` | Critical conditions |
+| `alert` | Immediate action required |
+| `emergency` | System is unusable |
+
+<Callout title="Enable Logging" type="warn">
+The server must have logging enabled for log messages to be delivered to the client. Enable it in your server configuration:
+
+```typescript
+new MCPServer({ logging: true });
+```
+</Callout>
+
+## Elicitation (Form Mode)
+
+Elicitation allows a tool to request structured user input mid-execution. This is useful when a tool needs additional information that was not provided in the initial request, such as confirmation, preferences, or form data.
+
+```typescript
+import { MCPTool, MCPInput } from "mcp-framework";
+import { z } from "zod";
+
+class RegistrationTool extends MCPTool {
+  name = "register_user";
+  description = "Register a new user with interactive form";
+
+  schema = z.object({
+    source: z.string().describe("Registration source"),
+  });
+
+  async execute(input: MCPInput<this>) {
+    const result = await this.elicit("Please provide your details", {
+      name: { type: "string", description: "Your full name" },
+      email: { type: "string", format: "email", description: "Email address" },
+      age: { type: "number", minimum: 18, optional: true },
+    });
+
+    if (result.action === 'accept') {
+      return `Hello ${result.content?.name}!`;
+    } else if (result.action === 'decline') {
+      return "User declined to provide information.";
+    }
+    return "Request was cancelled.";
+  }
+}
+```
+
+The `elicit` method returns an object with:
+- `action` — One of `'accept'`, `'decline'`, or `'cancel'`
+- `content` — The user's input (only present when `action` is `'accept'`)
+
+<Callout title="Security Warning" type="error">
+Do NOT request sensitive data (passwords, API keys, secrets) via form elicitation. The data may be visible in client UI and logs. Use URL mode instead for sensitive interactions.
+</Callout>
+
+## Elicitation (URL Mode)
+
+For sensitive interactions like OAuth flows, payment authorization, or credential entry, direct the user to an external URL instead of collecting data inline.
+
+```typescript
+async execute(input: MCPInput<this>) {
+  const result = await this.elicitUrl(
+    "Please authorize access to your account",
+    "https://auth.example.com/authorize?state=abc123",
+    "auth-flow-abc123"  // elicitation ID for tracking
+  );
+
+  if (result.action === 'accept') {
+    return "Authorization successful!";
+  }
+  return "Authorization was not completed.";
+}
+```
+
+URL mode is preferred when:
+- The interaction involves sensitive credentials
+- You need to integrate with an external authentication provider
+- The workflow requires a full web-based UI
+
+## Roots
+
+Roots represent the client's declared filesystem boundaries. Tools can query them to understand what directories or files the client has made available.
+
+```typescript
+import { MCPTool, MCPInput } from "mcp-framework";
+import { z } from "zod";
+
+class FileSearchTool extends MCPTool {
+  name = "file_search";
+  description = "Search files within client-declared roots";
+
+  schema = z.object({
+    pattern: z.string().describe("Search pattern"),
+  });
+
+  async execute(input: MCPInput<this>) {
+    const roots = await this.getRoots();
+    return roots.map(r => `${r.name ?? 'unnamed'}: ${r.uri}`);
+  }
+}
+```
+
+Each root object contains:
+- `uri` — The URI of the root (typically a `file://` URI)
+- `name` (optional) — A human-readable name for the root
+
+## Sampling with Tools
+
+Request LLM completions from the client, optionally including tool definitions that the LLM can invoke. This enables agentic patterns where a tool can delegate sub-tasks to the model.
+
+```typescript
+async execute(input: MCPInput<this>) {
+  const result = await this.samplingRequestWithTools({
+    messages: [
+      {
+        role: "user",
+        content: { type: "text", text: "What's the weather?" }
+      }
+    ],
+    maxTokens: 500,
+    tools: [{
+      name: "get_weather",
+      description: "Get weather for a city",
+      inputSchema: {
+        type: "object",
+        properties: {
+          city: { type: "string" }
+        },
+        required: ["city"]
+      }
+    }],
+    toolChoice: { mode: "auto" }
+  });
+
+  // Process the sampling result
+  return JSON.stringify(result);
+}
+```
+
+<Callout title="Client Support Required" type="info">
+Sampling requires the connected client to support the sampling capability. Not all MCP clients support this feature. Your tool should handle cases where sampling is unavailable.
+</Callout>
+
+## Tasks (Experimental)
+
+Tasks enable asynchronous tool execution. When a tool declares task support, clients can submit a request, receive a task ID, and poll for results later. This is ideal for operations that take a long time to complete.
+
+```typescript
+import { MCPTool } from "mcp-framework";
+import { z } from "zod";
+
+class LongRunningTool extends MCPTool {
+  name = "batch_process";
+  description = "Process a large batch of data";
+  execution = { taskSupport: 'optional' as const };
+
+  schema = z.object({
+    batchId: z.string().describe("Batch identifier"),
+  });
+
+  async execute(input) {
+    // Long-running work happens here
+    const result = await processLargeBatch(input.batchId);
+    return `Processed batch: ${result.count} items`;
+  }
+}
+```
+
+The `taskSupport` property accepts one of three values:
+
+| Value | Description |
+|---|---|
+| `'forbidden'` | Tool must not be run as a task (default) |
+| `'optional'` | Tool can run as a task or inline, at the client's discretion |
+| `'required'` | Tool must always run as a task |
+
+When a client sends a task-augmented request, the tool executes in the background and the client polls for results using the task ID.
+
+<Callout title="Enable Tasks on the Server" type="warn">
+Task support must be enabled in your server configuration:
+
+```typescript
+new MCPServer({ tasks: { enabled: true } });
+```
+
+Tasks are an experimental feature in the MCP specification and client support may vary.
+</Callout>
+
+## Next Steps
+
+- Review the [Tools Overview](overview) for fundamentals
+- Learn about [API Integration](api-integration) patterns
+- Explore [Prompts](../prompts/overview) and [Resources](../resources/overview)

--- a/content/docs/tools/meta.json
+++ b/content/docs/tools/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Tools",
-  "pages": ["overview", "api-integration"]
+  "pages": ["overview", "advanced-features", "api-integration"]
 }

--- a/content/docs/tools/overview.mdx
+++ b/content/docs/tools/overview.mdx
@@ -153,6 +153,150 @@ async execute(input: MyInput) {
 }
 ```
 
+## Title and Icons
+
+Tools can set a `title` for human-readable display and `icons` for client UI rendering. The `title` is separate from the programmatic `name` and is intended for display in tool pickers, dashboards, and other client interfaces.
+
+```typescript
+import { MCPTool } from "mcp-framework";
+import { z } from "zod";
+
+class WeatherTool extends MCPTool {
+  name = "get_weather";
+  title = "Weather Information";  // Human-readable display name
+  description = "Get current weather for a location";
+  icons = [{ src: "https://example.com/weather.png", mimeType: "image/png", sizes: ["48x48"] }];
+
+  schema = {
+    location: {
+      type: z.string(),
+      description: "City or address to get weather for",
+    },
+  };
+
+  async execute({ location }) {
+    // ...
+  }
+}
+```
+
+The `icons` property accepts an array of icon objects, each with:
+- `src` — URL to the icon image
+- `mimeType` — MIME type of the image (e.g., `"image/png"`, `"image/svg+xml"`)
+- `sizes` — Array of size strings (e.g., `["48x48", "96x96"]`)
+
+## Tool Annotations
+
+Annotations provide behavioral hints that help clients make UX decisions about your tools. For example, a client might auto-approve tools marked as read-only, or show a confirmation dialog for destructive tools.
+
+```typescript
+class DatabaseTool extends MCPTool {
+  name = "query_db";
+  description = "Query the database";
+  annotations = {
+    readOnlyHint: true,      // Tool doesn't modify state
+    destructiveHint: false,   // Tool is not destructive
+    idempotentHint: true,     // Safe to retry
+    openWorldHint: false,     // Doesn't access external systems
+  };
+
+  schema = {
+    query: {
+      type: z.string(),
+      description: "SQL query to execute",
+    },
+  };
+
+  async execute({ query }) {
+    // ...
+  }
+}
+```
+
+<Callout title="Annotations Are Hints" type="warn">
+Annotations are advisory only and are NOT enforced by the framework or the MCP protocol. Clients may use them to improve the user experience, but they should not be relied upon for security or correctness guarantees.
+</Callout>
+
+Available annotation properties:
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `readOnlyHint` | `boolean` | `false` | Tool does not modify any state |
+| `destructiveHint` | `boolean` | `true` | Tool may perform destructive operations |
+| `idempotentHint` | `boolean` | `false` | Calling the tool multiple times with the same input has the same effect |
+| `openWorldHint` | `boolean` | `true` | Tool may interact with external systems beyond its host |
+
+## New Content Types
+
+In addition to returning plain text, tools can now return audio content, resource links, and embedded resources.
+
+### Audio Content
+
+Return audio data as base64-encoded content:
+
+```typescript
+async execute(input) {
+  const audioData = await generateSpeech(input.text);
+  return { type: 'audio', data: audioData, mimeType: 'audio/wav' };
+}
+```
+
+### Resource Links
+
+Return a URI reference to an existing resource. The client can then fetch it independently:
+
+```typescript
+async execute(input) {
+  return {
+    type: 'resource_link',
+    uri: 'file:///project/src/main.rs',
+    name: 'main.rs',
+    mimeType: 'text/x-rust'
+  };
+}
+```
+
+### Embedded Resources
+
+Return a resource with inline content included directly in the response:
+
+```typescript
+async execute(input) {
+  return {
+    type: 'resource',
+    resource: {
+      uri: 'file:///README.md',
+      mimeType: 'text/markdown',
+      text: '# Hello'
+    }
+  };
+}
+```
+
+## Content Annotations
+
+All content types support optional annotations that indicate the intended audience, priority, and freshness of the content:
+
+```typescript
+async execute(input) {
+  return {
+    type: 'text',
+    text: 'Result for user',
+    annotations: {
+      audience: ['user'],           // Who this is for: 'user', 'assistant', or both
+      priority: 0.9,                // 0.0 (optional) to 1.0 (critical)
+      lastModified: '2025-01-12T15:00:58Z'
+    }
+  };
+}
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `audience` | `string[]` | Who the content is intended for. Values: `'user'`, `'assistant'`, or both. Omit to indicate both. |
+| `priority` | `number` | Importance from `0.0` (background/optional) to `1.0` (critical). Used by clients to order or filter content. |
+| `lastModified` | `string` | ISO 8601 timestamp of when the content was last modified. |
+
 ## Best Practices
 
 <Callout title="Pro Tips" type="info">
@@ -188,6 +332,7 @@ Following these practices will make your tools more reliable and maintainable!
 
 ## Next Steps
 
+- Explore [Advanced Tool Features](advanced-features) (progress, cancellation, logging, elicitation, tasks, and more)
 - Learn about [API Integration](api-integration)
 - Learn about [Prompts](../prompts/overview)
 - Learn about [Resources](../resources/overview)

--- a/content/docs/transports/http-stream.mdx
+++ b/content/docs/transports/http-stream.mdx
@@ -32,6 +32,7 @@ const server = new MCPServer({
     type: "http-stream",
     options: {
       port: 8080,                // Port to listen on (default: 8080)
+      host: "127.0.0.1",         // Host to bind to (default: "127.0.0.1")
       endpoint: "/mcp",          // HTTP endpoint path (default: "/mcp")
       responseMode: "batch",     // Response mode: "batch" or "stream" (default: "batch")
       maxMessageSize: "4mb",     // Maximum message size (default: "4mb")
@@ -99,10 +100,23 @@ This will create a new project with HTTP transport configured on port 1337 with 
 
 ## Configuration Options
 
-### Port and Endpoint
+### Port, Host, and Endpoint
 
 - `port`: The HTTP port to listen on (default: 8080)
+- `host`: The host address to bind to (default: `"127.0.0.1"`)
 - `endpoint`: The endpoint path for all MCP communication (default: "/mcp")
+
+The server binds to `127.0.0.1` by default for security. Set `host: '0.0.0.0'` to accept connections from other machines (required for Docker, cloud platforms).
+
+```typescript
+transport: {
+  type: "http-stream",
+  options: {
+    port: 8080,
+    host: "0.0.0.0", // Accept connections from any network interface
+  }
+}
+```
 
 ### Response Mode
 
@@ -151,6 +165,34 @@ cors: {
   maxAge: "86400"                 // Access-Control-Max-Age
 }
 ```
+
+### Origin Validation (DNS Rebinding Protection)
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+When `allowedOrigins` is configured within the `cors` block, the server validates the `Origin` header on every incoming request to protect against DNS rebinding attacks:
+
+```typescript
+cors: {
+  allowedOrigins: ["http://localhost:3000", "https://myapp.example.com"],
+  allowOrigin: "*",  // CORS Access-Control-Allow-Origin (separate from origin validation)
+  allowMethods: "GET, POST, DELETE, OPTIONS",
+  allowHeaders: "Content-Type, Accept, Authorization, x-api-key, Mcp-Session-Id, Last-Event-ID",
+  exposeHeaders: "Content-Type, Authorization, x-api-key, Mcp-Session-Id",
+  maxAge: "86400"
+}
+```
+
+How origin validation works:
+
+- Requests with an `Origin` header that does not match any entry in `allowedOrigins` receive an HTTP **403 Forbidden** response.
+- Requests **without** an `Origin` header (non-browser clients like `curl`, SDKs, and other server-side callers) are allowed through, since they are not subject to DNS rebinding.
+- `Origin: null` is **always rejected** when `allowedOrigins` is set. This is a security best practice, as `null` origins can be crafted by malicious pages.
+- When `allowedOrigins` is **not configured**, all origins are allowed. This preserves backwards compatibility with existing deployments.
+
+<Callout type="warn">
+For production deployments, always configure `allowedOrigins` to prevent DNS rebinding attacks.
+</Callout>
 
 ### Session Management
 
@@ -426,9 +468,11 @@ class HttpStreamClient {
 1. **HTTPS**: Always use HTTPS in production environments
 2. **Authentication**: Enable authentication for all endpoints
 3. **CORS**: Configure appropriate CORS settings for your environment
-4. **Message Size**: Set appropriate message size limits
-5. **Session Timeout**: Implement session timeout logic for production use
-6. **Rate Limiting**: Implement rate limiting for production use
+4. **Origin Validation**: Configure `allowedOrigins` to prevent DNS rebinding attacks
+5. **Host Binding**: Keep the default `127.0.0.1` binding unless external access is required
+6. **Message Size**: Set appropriate message size limits
+7. **Session Timeout**: Implement session timeout logic for production use
+8. **Rate Limiting**: Implement rate limiting for production use
 
 ## Backward Compatibility
 

--- a/content/docs/transports/overview.mdx
+++ b/content/docs/transports/overview.mdx
@@ -12,7 +12,7 @@ MCP Framework supports multiple transport mechanisms for communication between t
 The framework currently supports the following transport types:
 
 - **STDIO Transport**: The default transport that uses standard input/output streams
-- **HTTP Stream Transport**: Streamable HTTP transport that implements the MCP 2025-03-26 specification
+- **HTTP Stream Transport**: Streamable HTTP transport that implements the MCP 2025-11-25 specification
 - **SSE Transport**: **DEPRECATED** - Server-Sent Events based transport that has been replaced by HTTP Stream Transport
 
 ## Comparison
@@ -21,13 +21,15 @@ The framework currently supports the following transport types:
 |---------|----------------|-------------|---------------|
 | Protocol | Standard I/O streams | HTTP/SSE | HTTP/SSE |
 | Connection | Direct process communication | Network-based | Network-based |
-| Authentication | Not applicable | Supports JWT and API Key | Supports JWT and API Key |
+| Authentication | Not applicable | Supports JWT, API Key, and OAuth 2.1 | Supports JWT, API Key, and OAuth 2.1 |
 | Session Management | Not applicable | Built-in | Limited |
 | Resumability | Not applicable | Supported | No |
+| Host Binding | Not applicable | Configurable (default: localhost) | Configurable (default: localhost) |
+| Origin Validation | Not applicable | Supported (`allowedOrigins`) | Supported (`allowedOrigins`) |
 | Use Case | CLI tools, local integrations | Web applications, distributed systems | Legacy systems |
 | Configuration | Minimal | Highly configurable | Configurable |
 | Scalability | Single process | Multiple clients | Multiple clients |
-| MCP Specification | Compliant | 2025-03-26 compliant | Legacy (2024-11-05) |
+| MCP Specification | Compliant | 2025-11-25 compliant | Legacy (2024-11-05) |
 
 ## Choosing a Transport
 
@@ -101,6 +103,13 @@ const server = new MCPServer({
   }
 });
 ```
+
+## Transport Security Features
+
+Both the HTTP Stream and SSE transports include security features introduced in MCP spec 2025-11-25:
+
+- **Host Binding**: Servers bind to `127.0.0.1` (localhost only) by default. Set `host: '0.0.0.0'` to accept remote connections when deploying in Docker or cloud environments.
+- **Origin Validation**: Configure `allowedOrigins` in the `cors` block to validate the `Origin` header on every request, protecting against DNS rebinding attacks. Non-browser clients (without an `Origin` header) are allowed through. See the individual transport pages for full configuration details.
 
 For detailed information about each transport type, see:
 - [STDIO Transport](./stdio)

--- a/content/docs/transports/sse.mdx
+++ b/content/docs/transports/sse.mdx
@@ -21,6 +21,7 @@ const server = new MCPServer({
     type: "sse",
     options: {
       port: 8080,                // Port to listen on (default: 8080)
+      host: "127.0.0.1",         // Host to bind to (default: "127.0.0.1")
       endpoint: "/sse",          // SSE endpoint path (default: "/sse")
       messageEndpoint: "/messages", // Message endpoint path (default: "/messages")
       maxMessageSize: "4mb",     // Maximum message size (default: "4mb")
@@ -46,9 +47,21 @@ const server = new MCPServer({
 });
 ```
 
-### Port Configuration
+### Port and Host Configuration
 
 The `port` option specifies which port the SSE server should listen on. Default is 8080.
+
+The `host` option specifies the host address to bind to. Default is `"127.0.0.1"` (localhost only) for security. Set `host: '0.0.0.0'` to accept connections from other machines (required for Docker, cloud platforms).
+
+```typescript
+transport: {
+  type: "sse",
+  options: {
+    port: 8080,
+    host: "0.0.0.0", // Accept connections from any network interface
+  }
+}
+```
 
 ### Endpoints
 
@@ -83,6 +96,34 @@ cors: {
   maxAge: "86400"                    // Access-Control-Max-Age
 }
 ```
+
+### Origin Validation (DNS Rebinding Protection)
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+When `allowedOrigins` is configured within the `cors` block, the server validates the `Origin` header on every incoming request to protect against DNS rebinding attacks:
+
+```typescript
+cors: {
+  allowedOrigins: ["http://localhost:3000", "https://myapp.example.com"],
+  allowOrigin: "*",
+  allowMethods: "GET, POST, OPTIONS",
+  allowHeaders: "Content-Type, Authorization, x-api-key",
+  exposeHeaders: "Content-Type, Authorization, x-api-key",
+  maxAge: "86400"
+}
+```
+
+How origin validation works:
+
+- Requests with an `Origin` header that does not match any entry in `allowedOrigins` receive an HTTP **403 Forbidden** response.
+- Requests **without** an `Origin` header (non-browser clients like `curl`, SDKs, and other server-side callers) are allowed through, since they are not subject to DNS rebinding.
+- `Origin: null` is **always rejected** when `allowedOrigins` is set. This is a security best practice, as `null` origins can be crafted by malicious pages.
+- When `allowedOrigins` is **not configured**, all origins are allowed. This preserves backwards compatibility with existing deployments.
+
+<Callout type="warn">
+For production deployments, always configure `allowedOrigins` to prevent DNS rebinding attacks.
+</Callout>
 
 ### Authentication
 
@@ -149,8 +190,10 @@ Error responses include detailed information:
 1. **HTTPS**: Always use HTTPS in production environments
 2. **Authentication**: Enable authentication for both SSE and message endpoints
 3. **CORS**: Configure appropriate CORS settings for your environment
-4. **Message Size**: Set appropriate message size limits
-5. **Rate Limiting**: Implement rate limiting for production use
+4. **Origin Validation**: Configure `allowedOrigins` to prevent DNS rebinding attacks
+5. **Host Binding**: Keep the default `127.0.0.1` binding unless external access is required
+6. **Message Size**: Set appropriate message size limits
+7. **Rate Limiting**: Implement rate limiting for production use
 
 ## Client Implementation
 


### PR DESCRIPTION
## Summary

Updates all documentation to reflect the MCP 2025-11-25 spec compliance features implemented in [mcp-framework#156](https://github.com/QuantGeekDev/mcp-framework/pull/156).

## Pages updated (11 files, +829 lines)

| Page | Changes |
|------|---------|
| `introduction.mdx` | Updated key features list and component descriptions |
| `tools/overview.mdx` | Added title/icons, annotations, new content types, content annotations |
| **`tools/advanced-features.mdx`** | **NEW** — Structured content, progress, cancellation, logging, elicitation, roots, sampling with tools, tasks |
| `tools/meta.json` | Added advanced-features to navigation |
| `resources/overview.mdx` | Added title, icons, size, and annotations |
| `prompts/overview.mdx` | Added title and icons |
| `server-configuration.mdx` | Added logging and tasks config sections, updated example |
| `transports/http-stream.mdx` | Added host binding, origin validation |
| `transports/sse.mdx` | Added host binding, origin validation |
| `transports/overview.mdx` | Updated comparison table with security features |
| `authentication/overview.mdx` | Added OAuth 2.1 section |

## Test plan

- [ ] All pages render without errors in Fumadocs
- [ ] Navigation includes new "Advanced Tool Features" page under Tools
- [ ] Code examples are syntactically correct
- [ ] Cross-links between pages work
- [ ] New features are accurately documented per implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)