### PR TITLE
docs: add MCP Apps section with React guide

### DIFF
--- a/content/docs/apps/meta.json
+++ b/content/docs/apps/meta.json
@@ -1,0 +1,7 @@
+{
+  "title": "MCP Apps",
+  "pages": [
+    "overview",
+    "react"
+  ]
+}

--- a/content/docs/apps/overview.mdx
+++ b/content/docs/apps/overview.mdx
@@ -1,0 +1,319 @@
+---
+title: MCP Apps Overview
+description: Add interactive HTML UIs to your MCP tools — dashboards, forms, charts — that render inline in Claude, ChatGPT, VS Code, and other hosts
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+# MCP Apps
+
+<Callout title="Interactive UIs for MCP" type="info">
+MCP Apps let your tools deliver rich, interactive HTML experiences — dashboards, forms, charts, visualizations — directly inside Claude, ChatGPT, VS Code, and other MCP hosts.
+</Callout>
+
+## How It Works
+
+MCP Apps is built on the [SEP-1865 specification](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx), the first official MCP extension. The mechanism:
+
+1. Your server registers a `ui://` resource containing HTML
+2. Your tool definition includes `_meta.ui.resourceUri` pointing to that resource
+3. The host fetches the HTML and renders it in a sandboxed iframe
+4. The iframe communicates with the host via JSON-RPC over `postMessage`
+
+**Graceful degradation**: Hosts that don't support MCP Apps still see normal text tool results. Your `execute()` return value is always the text fallback.
+
+## Two Modes
+
+mcp-framework provides two ways to add MCP Apps:
+
+### Mode A: Standalone MCPApp
+
+For apps with multiple tools or complex UI, create an `MCPApp` subclass in `src/apps/`. The framework auto-discovers it just like tools, resources, and prompts.
+
+```typescript
+import { MCPApp } from "mcp-framework";
+import { z } from "zod";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+class DashboardApp extends MCPApp {
+  name = "dashboard";
+
+  ui = {
+    resourceUri: "ui://dashboard/view",
+    resourceName: "Analytics Dashboard",
+    resourceDescription: "Interactive analytics with charts and filters",
+    csp: {
+      connectDomains: ["https://api.analytics.com"],
+      resourceDomains: ["https://cdn.jsdelivr.net"],
+    },
+    prefersBorder: true,
+  };
+
+  getContent() {
+    return readFileSync(
+      join(__dirname, "../../app-views/dashboard/index.html"),
+      "utf-8"
+    );
+  }
+
+  tools = [
+    {
+      name: "show_dashboard",
+      description: "Display the analytics dashboard",
+      schema: z.object({
+        timeRange: z.string().describe("Time range (e.g., '7d', '30d')"),
+        metrics: z.array(z.string()).optional().describe("Metrics to display"),
+      }),
+      execute: async (input: { timeRange: string; metrics?: string[] }) => {
+        const data = await fetchAnalytics(input.timeRange, input.metrics);
+        return { data, summary: `Analytics for ${input.timeRange}` };
+      },
+    },
+    {
+      // App-only tool: the UI can call this, but the LLM can't see it
+      name: "refresh_data",
+      description: "Refresh a specific metric",
+      visibility: ["app"] as const,
+      schema: z.object({
+        metric: z.string().describe("Metric to refresh"),
+      }),
+      execute: async (input: { metric: string }) => {
+        return await fetchMetric(input.metric);
+      },
+    },
+  ];
+}
+
+export default DashboardApp;
+```
+
+### Mode B: Tool-Attached App
+
+For simpler cases, add a UI to an existing tool with the `app` property:
+
+```typescript
+import { MCPTool, MCPInput } from "mcp-framework";
+import { z } from "zod";
+import { readFileSync } from "fs";
+
+const schema = z.object({
+  location: z.string().describe("City name"),
+});
+
+class WeatherTool extends MCPTool {
+  name = "get_weather";
+  description = "Get weather with interactive visualization";
+  schema = schema;
+
+  app = {
+    resourceUri: "ui://weather/view",
+    resourceName: "Weather View",
+    content: () => readFileSync("./app-views/weather/index.html", "utf-8"),
+    csp: { connectDomains: ["https://api.openweathermap.org"] },
+  };
+
+  async execute(input: MCPInput<this>) {
+    const weather = await fetchWeather(input.location);
+    return weather; // Text fallback for non-UI hosts
+  }
+}
+
+export default WeatherTool;
+```
+
+## CLI Scaffolding
+
+Generate an app instantly:
+
+```bash
+mcp add app my-dashboard           # Vanilla HTML
+mcp add app my-dashboard --react   # React app
+mcp add tool my-widget --react     # Tool with React UI
+```
+
+## Project Structure
+
+```
+my-mcp-server/
+├── src/
+│   ├── tools/              # Regular tools (auto-discovered)
+│   ├── apps/               # MCPApp subclasses (auto-discovered)
+│   ├── app-views/          # HTML templates for apps
+│   │   └── my-dashboard/
+│   │       ├── index.html  # Vanilla, or Vite entry for React
+│   │       ├── App.tsx     # React component (--react only)
+│   │       └── styles.css  # Styles (--react only)
+│   ├── resources/
+│   ├── prompts/
+│   └── index.ts
+```
+
+## Writing the HTML View
+
+Your app's HTML runs inside a sandboxed iframe. Here's a minimal vanilla template:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <style>
+    :root {
+      --color-background-primary: light-dark(#ffffff, #1a1a1a);
+      --color-text-primary: light-dark(#1a1a1a, #fafafa);
+      --font-sans: system-ui, sans-serif;
+    }
+    body {
+      margin: 0; padding: 16px;
+      background: var(--color-background-primary);
+      color: var(--color-text-primary);
+      font-family: var(--font-sans);
+    }
+  </style>
+</head>
+<body>
+  <div id="app">Loading...</div>
+  <script type="module">
+    let nextId = 1;
+    function sendRequest(method, params) {
+      const id = nextId++;
+      return new Promise((resolve, reject) => {
+        function listener(event) {
+          if (event.data?.id === id) {
+            window.removeEventListener("message", listener);
+            event.data?.result ? resolve(event.data.result) : reject(event.data?.error);
+          }
+        }
+        window.addEventListener("message", listener);
+        window.parent.postMessage({ jsonrpc: "2.0", id, method, params }, "*");
+      });
+    }
+    function onNotification(method, handler) {
+      window.addEventListener("message", (event) => {
+        if (event.data?.method === method) handler(event.data.params);
+      });
+    }
+
+    // 1. Initialize
+    const init = await sendRequest("initialize", {
+      capabilities: {},
+      clientInfo: { name: "my-app", version: "1.0.0" },
+      protocolVersion: "2026-01-26",
+    });
+
+    // 2. Apply host theme
+    const vars = init.hostContext?.styles?.variables;
+    if (vars) {
+      for (const [key, value] of Object.entries(vars)) {
+        if (value) document.documentElement.style.setProperty(key, value);
+      }
+    }
+
+    // 3. Handle tool data
+    onNotification("ui/notifications/tool-input", (params) => {
+      document.getElementById("app").innerHTML =
+        "<pre>" + JSON.stringify(params.arguments, null, 2) + "</pre>";
+    });
+
+    onNotification("ui/notifications/tool-result", (params) => {
+      const text = params.content?.[0]?.text ?? JSON.stringify(params);
+      document.getElementById("app").innerHTML = "<pre>" + text + "</pre>";
+    });
+
+    // 4. Signal ready
+    window.parent.postMessage({
+      jsonrpc: "2.0", method: "notifications/initialized", params: {}
+    }, "*");
+  </script>
+</body>
+</html>
+```
+
+## UI Configuration
+
+### Content Security Policy (CSP)
+
+By default, the iframe has no network access. Declare allowed domains:
+
+```typescript
+ui = {
+  resourceUri: "ui://my-app/view",
+  resourceName: "My App",
+  csp: {
+    connectDomains: ["https://api.example.com"],     // fetch/XHR/WebSocket
+    resourceDomains: ["https://cdn.example.com"],     // scripts, images, fonts
+    frameDomains: ["https://youtube.com"],             // nested iframes
+  },
+};
+```
+
+### Permissions
+
+Request browser capabilities (not guaranteed — always use feature detection):
+
+```typescript
+ui = {
+  // ...
+  permissions: {
+    camera: {},
+    microphone: {},
+    geolocation: {},
+    clipboardWrite: {},
+  },
+};
+```
+
+### Tool Visibility
+
+Control who can call each tool:
+
+```typescript
+tools = [
+  {
+    name: "show_ui",
+    visibility: ["model", "app"],  // Default: LLM and UI can both call
+    // ...
+  },
+  {
+    name: "refresh_data",
+    visibility: ["app"],           // Only the UI can call (hidden from LLM)
+    // ...
+  },
+];
+```
+
+## Dev Mode
+
+In development, app HTML is re-read from disk on every request:
+
+```typescript
+const server = new MCPServer({
+  devMode: true,  // Or set MCP_DEV_MODE=1 env var
+});
+```
+
+In production (default), HTML is cached at startup for performance.
+
+## Client Support
+
+MCP Apps is supported by:
+- **Claude** (web and desktop)
+- **ChatGPT**
+- **VS Code** (GitHub Copilot)
+- **Goose**
+- **Postman**
+
+Hosts that don't support MCP Apps see normal text tool results — your server works everywhere.
+
+## Use Cases
+
+- **Data dashboards** — interactive charts with drill-down and filtering
+- **Configuration wizards** — multi-step forms with validation
+- **Code diff viewers** — syntax-highlighted diffs with inline comments
+- **Map/location pickers** — interactive maps for coordinate selection
+- **Document reviewers** — annotatable document views
+- **Database explorers** — sortable, filterable query result tables

--- a/content/docs/apps/react.mdx
+++ b/content/docs/apps/react.mdx
@@ -1,0 +1,263 @@
+---
+title: React Apps
+description: Build interactive MCP App UIs with React using the ext-apps SDK hooks
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+# React Apps
+
+<Callout title="React Support" type="info">
+Use `--react` with `mcp add app` or `mcp add tool` to scaffold a complete React-based MCP App with Vite bundling, host theme integration, and the official ext-apps SDK hooks.
+</Callout>
+
+## Quick Start
+
+### Standalone React App (Mode A)
+
+```bash
+mcp add app my-dashboard --react
+```
+
+### Tool with React UI (Mode B)
+
+```bash
+mcp add tool my-widget --react
+```
+
+Both generate:
+
+```
+src/app-views/<name>/
+├── App.tsx           # React component with useApp() wired up
+├── styles.css        # Host theme fallbacks + base styles
+├── index.html        # Vite entry (<div id="root">)
+├── vite.config.ts    # react() + viteSingleFile()
+└── tsconfig.json     # Client-side config (react-jsx, DOM)
+```
+
+## Install Dependencies
+
+After scaffolding, install the React and build dependencies:
+
+```bash
+npm install @modelcontextprotocol/ext-apps @modelcontextprotocol/sdk react react-dom
+npm install -D @types/react @types/react-dom @vitejs/plugin-react vite vite-plugin-singlefile
+```
+
+## Build the View
+
+MCP Apps requires a single HTML file with all JS/CSS inlined. Vite + `vite-plugin-singlefile` handles this:
+
+```bash
+cd src/app-views/my-dashboard && npx vite build
+```
+
+The output lands in `src/app-views/my-dashboard/dist/index.html` — the file your MCPApp or tool reads via `getContent()`.
+
+<Callout title="Build Order" type="warn">
+Build your app views **before** running `tsc`. Add this to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "build:views": "cd src/app-views/my-dashboard && npx vite build",
+    "build": "npm run build:views && tsc"
+  }
+}
+```
+</Callout>
+
+## How the Generated Component Works
+
+The scaffolded `App.tsx` uses `useApp()` from `@modelcontextprotocol/ext-apps/react`:
+
+```tsx
+import { useApp } from "@modelcontextprotocol/ext-apps/react";
+import type { App as McpApp, McpUiHostContext } from "@modelcontextprotocol/ext-apps";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { StrictMode, useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import "./styles.css";
+
+function MyDashboard() {
+  const [toolInput, setToolInput] = useState<Record<string, unknown> | null>(null);
+  const [toolResult, setToolResult] = useState<CallToolResult | null>(null);
+  const [hostContext, setHostContext] = useState<McpUiHostContext | undefined>();
+
+  const { app, error } = useApp({
+    appInfo: { name: "my-dashboard", version: "1.0.0" },
+    capabilities: {},
+    onAppCreated: (app: McpApp) => {
+      // Register handlers BEFORE connection
+      app.ontoolinput = (params) => setToolInput(params.arguments ?? null);
+      app.ontoolresult = (result) => setToolResult(result);
+      app.ontoolcancelled = (params) => console.info("Cancelled:", params.reason);
+      app.onhostcontextchanged = (params) =>
+        setHostContext((prev) => ({ ...prev, ...params }));
+    },
+  });
+
+  // Get initial host context after connection
+  useEffect(() => {
+    if (app) setHostContext(app.getHostContext());
+  }, [app]);
+
+  // Apply host theme variables
+  useEffect(() => {
+    const vars = hostContext?.styles?.variables;
+    if (vars) {
+      for (const [key, value] of Object.entries(vars)) {
+        if (value) document.documentElement.style.setProperty(key, String(value));
+      }
+    }
+    if (hostContext?.theme) {
+      document.documentElement.style.colorScheme = hostContext.theme;
+    }
+  }, [hostContext]);
+
+  if (error) return <div className="error">Error: {error.message}</div>;
+  if (!app) return <div className="loading">Connecting...</div>;
+
+  return (
+    <div className="container">
+      <h2>My Dashboard</h2>
+      {toolInput && <pre>{JSON.stringify(toolInput, null, 2)}</pre>}
+      {toolResult && <pre>{JSON.stringify(toolResult, null, 2)}</pre>}
+    </div>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <MyDashboard />
+  </StrictMode>
+);
+```
+
+## Calling Server Tools from the UI
+
+Your React app can call tools on the MCP server via `app.callServerTool()`:
+
+```tsx
+const handleRefresh = async () => {
+  const result = await app.callServerTool({
+    name: "refresh_data",
+    arguments: { metric: "revenue" },
+  });
+  setData(result);
+};
+```
+
+This is proxied by the host to the MCP server. Combine with [app-only tools](/docs/apps/overview#tool-visibility) (`visibility: ["app"]`) for operations the LLM shouldn't see.
+
+## Sending Messages to the Chat
+
+Your app can send messages back to the conversation:
+
+```tsx
+const handleSubmit = async () => {
+  await app.sendMessage({
+    role: "user",
+    content: [{ type: "text", text: `User selected: ${selection}` }],
+  });
+};
+```
+
+## Updating Model Context
+
+Provide data to the LLM for future turns without sending a visible message:
+
+```tsx
+await app.updateModelContext({
+  content: [{ type: "text", text: `Current filter: ${filterState}` }],
+});
+```
+
+## Host Theme Integration
+
+The generated `styles.css` includes fallback values for all host theme variables. When running in Claude, ChatGPT, or VS Code, the host provides its actual theme values and your app automatically matches.
+
+Key CSS variables available:
+
+| Variable | Purpose |
+|----------|---------|
+| `--color-background-primary` | Main background |
+| `--color-background-secondary` | Card/section background |
+| `--color-text-primary` | Primary text |
+| `--color-text-secondary` | Muted text |
+| `--color-border-primary` | Borders |
+| `--font-sans` | Sans-serif font family |
+| `--font-mono` | Monospace font family |
+| `--border-radius-md` | Default border radius |
+
+All variables use `light-dark()` for automatic light/dark mode support.
+
+## Available React Hooks
+
+The `@modelcontextprotocol/ext-apps/react` package provides:
+
+| Hook | Purpose |
+|------|---------|
+| `useApp()` | Creates App instance, connects to host, returns `{app, isConnected, error}` |
+| `useHostStyles()` | Applies host CSS variables + fonts automatically |
+| `useDocumentTheme()` | Reactive light/dark theme tracking |
+| `useAutoResize()` | Reports size changes to host (enabled by default) |
+
+## Dev Workflow
+
+For the best development experience, run Vite watch and your server in parallel:
+
+```json
+{
+  "scripts": {
+    "dev:views": "cd src/app-views/my-dashboard && npx vite build --watch",
+    "dev:server": "npx tsx --watch src/index.ts",
+    "dev": "concurrently \"npm run dev:views\" \"npm run dev:server\""
+  }
+}
+```
+
+With `devMode: true` on your MCPServer (or `MCP_DEV_MODE=1`), the server re-reads HTML on every request — so Vite rebuilds + server picks it up automatically.
+
+## Example: Interactive Counter
+
+A minimal React MCP App:
+
+```tsx
+import { useApp } from "@modelcontextprotocol/ext-apps/react";
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+function Counter() {
+  const [count, setCount] = useState(0);
+  const { app } = useApp({
+    appInfo: { name: "counter", version: "1.0.0" },
+    onAppCreated: (app) => {
+      app.ontoolinput = (params) => {
+        if (params.arguments?.initial) {
+          setCount(Number(params.arguments.initial));
+        }
+      };
+    },
+  });
+
+  if (!app) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2>Count: {count}</h2>
+      <button onClick={() => setCount(c => c + 1)}>+</button>
+      <button onClick={() => setCount(c => c - 1)}>-</button>
+      <button onClick={() => setCount(0)}>Reset</button>
+      <button onClick={() => app.updateModelContext({
+        content: [{ type: "text", text: `Counter value: ${count}` }]
+      })}>
+        Send to Chat
+      </button>
+    </div>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<Counter />);
+```

--- a/content/docs/introduction.mdx
+++ b/content/docs/introduction.mdx
@@ -22,6 +22,7 @@ You can build a MCP server with mcp-framework in under 5 minutes! [Follow the qu
 ## Key Features
 
 - **Tool Support**: Create custom tools with annotations, structured output schemas, and rich content types (text, images, audio, resource links)
+- **MCP Apps**: Add interactive HTML UIs (dashboards, forms, charts) to your tools — renders inline in Claude, ChatGPT, VS Code ([React support](./apps/react) included)
 - **Resource Management**: Handle external data sources with title, icons, size, and annotation metadata
 - **Prompt Templates**: Define reusable prompt templates with display metadata
 - **Multiple Transports**: STDIO, HTTP Stream (recommended), and SSE with security features (origin validation, localhost binding)

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -9,6 +9,7 @@
     "debugging",
     "---",
     "tools",
+    "apps",
     "transports",
     "authentication",
     "resources",


### PR DESCRIPTION
## Summary

- Adds new **MCP Apps** documentation section to the site (between Tools and Transports in nav)
- Two pages: **Overview** (full guide) and **React** (React-specific guide)
- Updates introduction to mention MCP Apps in key features

## New pages

### apps/overview.mdx
- How MCP Apps works (SEP-1865)
- Mode A: Standalone MCPApp with full code example
- Mode B: Tool-attached app with full code example
- CLI scaffolding (`mcp add app`, `mcp add tool --react`)
- Writing HTML views (vanilla template)
- CSP configuration, permissions, tool visibility
- Dev mode, client support matrix, use cases

### apps/react.mdx
- Quick start with `--react` flag
- Generated file structure
- Dependency installation
- Vite bundling (single HTML output)
- `useApp()` hook walkthrough with full component example
- Calling server tools from UI (`app.callServerTool()`)
- Sending messages to chat (`app.sendMessage()`)
- Updating model context (`app.updateModelContext()`)
- Host theme integration (CSS variables table)
- Available React hooks reference
- Dev workflow (Vite watch + server watch)
- Interactive counter example

🤖 Generated with [Claude Code](https://claude.com/claude-code)