### PR TITLE
docs: add multi-transport documentation

### DIFF
--- a/content/docs/server-configuration.mdx
+++ b/content/docs/server-configuration.mdx
@@ -62,20 +62,36 @@ The transport configuration determines how clients will communicate with your se
 ```typescript
 const server = new MCPServer({
   transport: {
-    type: "sse",              // "sse" or "stdio"
+    type: "http-stream",
     options: {
-      // Transport-specific options
       port: 8080,
-      endpoint: "/sse",
+      endpoint: "/mcp",
       // ... other options
     }
   }
 });
 ```
 
+### Multi-Transport
+
+You can also run multiple transports concurrently using the `transports` array:
+
+```typescript
+const server = new MCPServer({
+  transports: [
+    { type: "stdio" },
+    { type: "http-stream", options: { port: 8080 } },
+  ],
+});
+```
+
+See [Multi-Transport](./transports/multi-transport) for full details on running multiple transports simultaneously.
+
 See the transport-specific documentation for detailed configuration options:
-- [SSE Transport](./transports/sse)
+- [Multi-Transport](./transports/multi-transport)
 - [STDIO Transport](./transports/stdio)
+- [HTTP Stream Transport](./transports/http-stream)
+- [SSE Transport](./transports/sse)
 
 ## Server Capabilities
 

--- a/content/docs/transports/meta.json
+++ b/content/docs/transports/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Transports",
-  "pages": ["overview", "stdio", "http-stream", "sse"]
+  "pages": ["overview", "multi-transport", "stdio", "http-stream", "serverless", "sse"]
 }

--- a/content/docs/transports/multi-transport.mdx
+++ b/content/docs/transports/multi-transport.mdx
@@ -1,0 +1,199 @@
+---
+title: Multi-Transport
+description: Run multiple transports concurrently from a single MCP server
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+# Multi-Transport
+
+MCP Framework supports running multiple transports simultaneously from a single server instance. This allows you to serve clients over stdio (for local tools like Claude Desktop) and HTTP Stream or SSE (for remote clients) at the same time, all sharing the same tools, prompts, and resources.
+
+## Quick Start
+
+Use the `transports` array instead of the singular `transport` field:
+
+```typescript
+import { MCPServer } from "mcp-framework";
+
+const server = new MCPServer({
+  name: "my-server",
+  transports: [
+    { type: "stdio" },
+    { type: "http-stream", options: { port: 8080 } },
+  ],
+});
+
+await server.start();
+```
+
+This starts a single server that listens on both stdio and HTTP Stream port 8080. Tools, prompts, and resources are loaded once and shared across all transports.
+
+## Configuration
+
+### `transports` vs `transport`
+
+You can use either the singular `transport` (existing API, still fully supported) or the plural `transports` array, but not both:
+
+```typescript
+// Single transport (original API - still works)
+const server = new MCPServer({
+  transport: { type: "stdio" },
+});
+
+// Multiple transports (new API)
+const server = new MCPServer({
+  transports: [
+    { type: "stdio" },
+    { type: "sse", options: { port: 3001 } },
+    { type: "http-stream", options: { port: 8080 } },
+  ],
+});
+```
+
+<Callout type="warn">
+Providing both `transport` and `transports` will throw an error at construction time.
+</Callout>
+
+### Per-Transport Authentication
+
+Each transport can have its own authentication configuration. This is useful when you want stdio (local) to be unauthenticated while HTTP (remote) requires auth:
+
+```typescript
+import { MCPServer, APIKeyAuthProvider } from "mcp-framework";
+
+const server = new MCPServer({
+  transports: [
+    { type: "stdio" },  // No auth needed for local
+    {
+      type: "http-stream",
+      options: { port: 8080 },
+      auth: {
+        provider: new APIKeyAuthProvider({ keys: [process.env.API_KEY!] }),
+      },
+    },
+  ],
+});
+```
+
+### Per-Transport Options
+
+Each transport entry accepts the same `options` and `auth` fields as the singular `transport` config. See the individual transport pages for all available options:
+
+- [STDIO Transport](./stdio) -- no options needed
+- [HTTP Stream Transport](./http-stream) -- port, endpoint, responseMode, CORS, auth, session config
+- [SSE Transport](./sse) -- port, endpoint, CORS, auth
+
+## Validation Rules
+
+The framework validates your transport configuration at construction time:
+
+### stdio Singleton
+
+Only one stdio transport is allowed since stdin/stdout is a process-level singleton:
+
+```typescript
+// This throws an error
+const server = new MCPServer({
+  transports: [
+    { type: "stdio" },
+    { type: "stdio" },  // Error: only one stdio allowed
+  ],
+});
+```
+
+### Port Conflicts
+
+Two HTTP-based transports cannot use the same port:
+
+```typescript
+// This throws an error
+const server = new MCPServer({
+  transports: [
+    { type: "sse", options: { port: 8080 } },
+    { type: "http-stream", options: { port: 8080 } },  // Error: port conflict
+  ],
+});
+```
+
+<Callout type="info">
+Both SSE and HTTP Stream default to port 8080. If you use both without specifying ports, a port conflict error will be raised. Always specify different ports when combining HTTP-based transports.
+</Callout>
+
+## How It Works
+
+Under the hood, multi-transport uses a **TransportBinding** model. Each transport gets its own MCP SDK `Server` instance, but all instances share the same tool, prompt, and resource registrations:
+
+```
+MCPServer
+  +-- toolsMap, promptsMap, resourcesMap (shared)
+  +-- capabilities (computed once)
+  |
+  +-- bindings[]
+       +-- [0] stdio   <-> SDK Server #1
+       +-- [1] SSE:3001 <-> SDK Server #2
+       +-- [2] HTTP:8080 <-> SDK Server #3
+```
+
+When a tool is invoked, the server automatically injects the correct SDK Server reference so that progress notifications, sampling requests, and root queries route back through the transport that received the request.
+
+## Lifecycle
+
+### Startup
+
+All transports connect concurrently when `start()` is called. If any transport fails to start (e.g., port already in use), the entire `start()` call fails.
+
+### Shutdown
+
+Calling `stop()` closes all transports and their SDK Server instances concurrently. The server also shuts down gracefully on `SIGINT`/`SIGTERM`.
+
+If a single transport closes at runtime (e.g., a network transport disconnects), only that binding is removed. The server continues operating on the remaining transports. When the last transport closes, the server shuts down automatically.
+
+## Common Patterns
+
+### Local + Remote
+
+The most common use case -- serve local clients via stdio and remote clients via HTTP:
+
+```typescript
+const server = new MCPServer({
+  name: "my-server",
+  transports: [
+    { type: "stdio" },
+    { type: "http-stream", options: { port: 8080 } },
+  ],
+});
+```
+
+### HTTP + SSE Fallback
+
+Serve modern clients via HTTP Stream while providing an SSE fallback for older clients:
+
+```typescript
+const server = new MCPServer({
+  name: "my-server",
+  transports: [
+    { type: "http-stream", options: { port: 8080 } },
+    { type: "sse", options: { port: 3001 } },
+  ],
+});
+```
+
+### All Three Transports
+
+Maximize compatibility by listening on everything:
+
+```typescript
+import { MCPServer, OAuthAuthProvider } from "mcp-framework";
+
+const oauthProvider = new OAuthAuthProvider({ /* ... */ });
+
+const server = new MCPServer({
+  name: "my-server",
+  transports: [
+    { type: "stdio" },
+    { type: "sse", options: { port: 3001 }, auth: { provider: oauthProvider } },
+    { type: "http-stream", options: { port: 8080 }, auth: { provider: oauthProvider } },
+  ],
+});
+```

--- a/content/docs/transports/overview.mdx
+++ b/content/docs/transports/overview.mdx
@@ -13,23 +13,21 @@ The framework currently supports the following transport types:
 
 - **STDIO Transport**: The default transport that uses standard input/output streams
 - **HTTP Stream Transport**: Streamable HTTP transport that implements the MCP 2025-11-25 specification
+- **Serverless (Lambda)**: Stateless request handling for AWS Lambda, Cloudflare Workers, and other serverless platforms
 - **SSE Transport**: **DEPRECATED** - Server-Sent Events based transport that has been replaced by HTTP Stream Transport
 
 ## Comparison
 
-| Feature | STDIO Transport | HTTP Stream Transport | SSE Transport (Deprecated) |
-|---------|----------------|-------------|---------------|
-| Protocol | Standard I/O streams | HTTP/SSE | HTTP/SSE |
-| Connection | Direct process communication | Network-based | Network-based |
-| Authentication | Not applicable | Supports JWT, API Key, and OAuth 2.1 | Supports JWT, API Key, and OAuth 2.1 |
-| Session Management | Not applicable | Built-in | Limited |
-| Resumability | Not applicable | Supported | No |
-| Host Binding | Not applicable | Configurable (default: localhost) | Configurable (default: localhost) |
-| Origin Validation | Not applicable | Supported (`allowedOrigins`) | Supported (`allowedOrigins`) |
-| Use Case | CLI tools, local integrations | Web applications, distributed systems | Legacy systems |
-| Configuration | Minimal | Highly configurable | Configurable |
-| Scalability | Single process | Multiple clients | Multiple clients |
-| MCP Specification | Compliant | 2025-11-25 compliant | Legacy (2024-11-05) |
+| Feature | STDIO | HTTP Stream | Serverless (Lambda) | SSE (Deprecated) |
+|---------|-------|-------------|--------------------|--------------------|
+| Protocol | Standard I/O streams | HTTP/SSE | HTTP (JSON batch) | HTTP/SSE |
+| Connection | Direct process | Network-based | Per-request | Network-based |
+| Authentication | N/A | JWT, API Key, OAuth 2.1 | JWT, API Key, OAuth 2.1 | JWT, API Key, OAuth 2.1 |
+| Session Management | N/A | Built-in | Stateless | Limited |
+| Resumability | N/A | Supported | No | No |
+| Use Case | CLI tools, local | Web apps, distributed | Lambda, Workers, Edge | Legacy systems |
+| Scalability | Single process | Multiple clients | Auto-scaling | Multiple clients |
+| MCP Specification | Compliant | 2025-11-25 | 2025-11-25 (stateless) | Legacy (2024-11-05) |
 
 ## Choosing a Transport
 
@@ -49,6 +47,12 @@ Choose your transport based on your application's needs:
   - Need resumable connections
   - Need to scale horizontally
   - Require compliance with latest MCP specification
+
+- Use **Serverless (Lambda)** when:
+  - Deploying on AWS Lambda, Cloudflare Workers, or Vercel Edge
+  - Need auto-scaling without managing infrastructure
+  - Want pay-per-request pricing
+  - Building stateless APIs
 
 - Use **SSE Transport** only for:
   - Legacy applications that depend on the older transport
@@ -86,6 +90,27 @@ const server = new MCPServer({
 });
 ```
 
+### Serverless (Lambda)
+
+```typescript
+import { MCPServer } from 'mcp-framework';
+import { MyTool } from './tools/MyTool.js';
+
+const server = new MCPServer({
+  name: 'my-server',
+  version: '1.0.0',
+});
+server.addTool(MyTool);
+
+// AWS Lambda
+export const handler = server.createLambdaHandler();
+
+// Cloudflare Workers / generic
+export default {
+  fetch: (request: Request) => server.handleRequest(request),
+};
+```
+
 ### SSE Transport (Deprecated)
 
 ```typescript
@@ -111,7 +136,24 @@ Both the HTTP Stream and SSE transports include security features introduced in 
 - **Host Binding**: Servers bind to `127.0.0.1` (localhost only) by default. Set `host: '0.0.0.0'` to accept remote connections when deploying in Docker or cloud environments.
 - **Origin Validation**: Configure `allowedOrigins` in the `cors` block to validate the `Origin` header on every request, protecting against DNS rebinding attacks. Non-browser clients (without an `Origin` header) are allowed through. See the individual transport pages for full configuration details.
 
+## Multi-Transport
+
+You can run multiple transports simultaneously from a single server instance using the `transports` array config. This is useful when you need to serve both local clients (via stdio) and remote clients (via HTTP) at the same time:
+
+```typescript
+const server = new MCPServer({
+  transports: [
+    { type: "stdio" },
+    { type: "http-stream", options: { port: 8080 } },
+  ],
+});
+```
+
+Tools, prompts, and resources are loaded once and shared across all transports. See [Multi-Transport](./multi-transport) for full details.
+
 For detailed information about each transport type, see:
+- [Multi-Transport](./multi-transport) - Running multiple transports concurrently
 - [STDIO Transport](./stdio)
 - [HTTP Stream Transport](./http-stream)
+- [Serverless (Lambda)](./serverless)
 - [SSE Transport](./sse) (Deprecated)


### PR DESCRIPTION
## Summary

Documents the new multi-transport feature from QuantGeekDev/mcp-framework#164.

- New `content/docs/transports/multi-transport.mdx` page covering:
  - Quick start with `transports` array config
  - `transports` vs `transport` (backward compat)
  - Per-transport authentication
  - Validation rules (stdio singleton, port conflicts)
  - TransportBinding architecture overview
  - Lifecycle (startup, shutdown, partial failure)
  - Common patterns (local+remote, HTTP+SSE fallback, all three)
- Updated transport overview with multi-transport section
- Updated server-configuration with multi-transport example
- Added to navigation in `meta.json`

## Test plan

- [ ] Verify page renders correctly in Fumadocs
- [ ] Check all internal links resolve
- [ ] Code examples match the implementation in mcp-framework#164

🤖 Generated with [Claude Code](https://claude.com/claude-code)